### PR TITLE
Add public pages and DeepSeek-ready AI provider layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,9 +29,15 @@ JWT_EXPIRES_IN=7d
 JWT_REFRESH_SECRET=your_refresh_secret_key
 JWT_REFRESH_EXPIRES_IN=30d
 
-# --- OpenAI API ---
-# Optional for boot; required for chat parsing and AI insights
-OPENAI_API_KEY=sk-your_openai_api_key
+# --- AI Provider ---
+# Defaults to DeepSeek when DEEPSEEK_API_KEY is present.
+AI_PROVIDER=deepseek
+DEEPSEEK_API_KEY=your_deepseek_api_key
+DEEPSEEK_MODEL=deepseek-chat
+
+# --- Legacy OpenAI Fallback (optional) ---
+# Keep only if you still want a fallback provider during migration.
+OPENAI_API_KEY=
 OPENAI_MODEL=gpt-4o-mini
 
 # --- Encryption ---

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ LifeSync is a full-stack health and finance tracking app with:
 
 - Express + Sequelize + MySQL backend
 - React + Vite frontend
-- OpenAI-powered NLP chat for logging entries
+- DeepSeek-powered NLP chat for logging entries
 - Optional Firebase sync for chat history
 - OTP-based registration flow via email
+- Public landing, privacy, and terms pages for Google-ready deployment
 
 ## Verified Status
 
@@ -29,7 +30,8 @@ $env:NODE_ENV='test'
 $env:JWT_SECRET='test_jwt_secret_for_ci_pipeline_32ch'
 $env:JWT_REFRESH_SECRET='test_refresh_secret_for_ci_pipe'
 $env:ENCRYPTION_KEY='test_encryption_key_for_ci_32ch!'
-$env:OPENAI_API_KEY='sk-test'
+$env:AI_PROVIDER='deepseek'
+$env:DEEPSEEK_API_KEY='ds-test'
 npm test -- --forceExit --detectOpenHandles
 ```
 
@@ -50,7 +52,7 @@ To run the full app locally you need:
 - MySQL 8+
 - an `.env` file for the backend
 - an `.env` file for the frontend
-- a valid OpenAI API key for real NLP chat behavior
+- a valid DeepSeek API key for real NLP chat behavior
 - a real SMTP provider for production OTP emails
 - Firebase credentials if you want real-time chat sync
 
@@ -83,7 +85,9 @@ DB_PASSWORD=your_mysql_password
 JWT_SECRET=replace_with_a_real_32_plus_char_secret
 JWT_REFRESH_SECRET=replace_with_a_second_real_secret
 ENCRYPTION_KEY=replace_with_a_real_32_plus_char_key
-OPENAI_API_KEY=sk-...
+AI_PROVIDER=deepseek
+DEEPSEEK_API_KEY=ds-...
+DEEPSEEK_MODEL=deepseek-chat
 CORS_ORIGIN=http://localhost:5173
 APP_URL=http://localhost:5000
 ```
@@ -126,7 +130,8 @@ npm run build
 
 ## Environment Notes
 
-- `OPENAI_API_KEY` must be present before the backend boots because the OpenAI client is created at module load time.
+- `DEEPSEEK_API_KEY` is required for live chat parsing and model-backed summaries when `AI_PROVIDER=deepseek`.
+- If you keep `OPENAI_API_KEY`, the backend can still use OpenAI as a temporary fallback until you finish the migration.
 - Firebase is optional. If it is not configured, Firebase-backed chat sync is skipped.
 - SMTP is optional in development. In production, use a real provider.
 - For Gmail SMTP, set `SMTP_HOST=smtp.gmail.com`, `SMTP_PORT=587`, `SMTP_SECURE=false`, and set `SMTP_FROM_EMAIL` to the same Gmail address as `SMTP_USER`.
@@ -156,8 +161,8 @@ This project is close to a strong student/demo app, but it is not yet production
 6. The seed script creates a default admin with a known password.
    That is acceptable for local development only and must be removed or overridden for real deployment.
 
-7. The backend depends on OpenAI credentials at startup.
-   If the key is missing, the app can fail before a user ever hits the chat route.
+7. Google Fit still requires production OAuth configuration on the Google Cloud side.
+   The app needs a real callback URL, consent screen URLs, and approved origins before that integration is launch-ready.
 
 ### Missing production infrastructure
 
@@ -170,11 +175,9 @@ This project is close to a strong student/demo app, but it is not yet production
 
 ### Missing launch readiness items
 
-1. Privacy policy and terms of service
-2. Data retention and account deletion policy
-3. Production incident logging and alerting
-4. Password reset / account recovery flow
-5. Load testing and basic security review
+1. Google Cloud consent-screen setup using the live homepage, privacy, and terms URLs
+2. Production incident logging and alerting
+3. Load testing and basic security review
 
 ## Recommended Production Architecture
 
@@ -207,9 +210,13 @@ Those scripts also install the frontend dependencies inside `client/` before run
 - `server/middleware/rateLimiter.js`
 - `server/services/otpService.js`
 - `server/services/ai/nlpService.js`
+- `server/services/ai/providerClient.js`
 - `server/utils/encryption.js`
 - `server/seeders/seed.js`
 - `client/src/App.jsx`
+- `client/src/pages/LandingPage.jsx`
+- `client/src/pages/PrivacyPolicyPage.jsx`
+- `client/src/pages/TermsPage.jsx`
 - `client/src/services/api.js`
 - `client/nginx.conf`
 - `docker-compose.yml`

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,8 +2,11 @@ import { lazy, Suspense } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, Outlet } from 'react-router-dom';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 
+import LandingPage from './pages/LandingPage';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
+import PrivacyPolicyPage from './pages/PrivacyPolicyPage';
+import TermsPage from './pages/TermsPage';
 import ForgotPasswordPage from './pages/ForgotPasswordPage';
 import NotFoundPage from './pages/NotFoundPage';
 import AppLayout from './components/layout/AppLayout';
@@ -68,7 +71,8 @@ function PublicRoute() {
 function RootRoute() {
   const { user, loading } = useAuth();
   if (loading) return <LoadingScreen />;
-  return <Navigate to={user ? '/dashboard' : '/login'} replace />;
+  if (user) return <Navigate to="/dashboard" replace />;
+  return <LandingPage />;
 }
 
 export default function App() {
@@ -77,6 +81,8 @@ export default function App() {
       <AuthProvider>
         <Routes>
           <Route path="/" element={<RootRoute />} />
+          <Route path="/privacy" element={<PrivacyPolicyPage />} />
+          <Route path="/terms" element={<TermsPage />} />
 
           <Route element={<PublicRoute />}>
             <Route path="/login" element={<LoginPage />} />

--- a/client/src/pages/LandingPage.jsx
+++ b/client/src/pages/LandingPage.jsx
@@ -1,0 +1,336 @@
+import { Link } from 'react-router-dom';
+import {
+  Activity,
+  MessageCircle,
+  Heart,
+  Wallet,
+  Zap,
+  ArrowRight,
+  Star,
+  BarChart3,
+  Brain,
+  Lock,
+  ChevronDown,
+  Sparkles,
+} from 'lucide-react';
+
+const features = [
+  {
+    icon: Brain,
+    bg: 'bg-emerald-50',
+    text: 'text-emerald-600',
+    title: 'AI-Powered Insights',
+    desc: 'Natural language understanding lets you log health and finances just by describing your day. LifeSync figures out the rest.',
+  },
+  {
+    icon: Heart,
+    bg: 'bg-coral-50',
+    text: 'text-coral-500',
+    title: 'Health Tracking',
+    desc: 'Steps, sleep, mood, hydration, and exercise in one place. Spot wellness patterns and correlations you never knew existed.',
+  },
+  {
+    icon: Wallet,
+    bg: 'bg-amber-50',
+    text: 'text-amber-500',
+    title: 'Finance Management',
+    desc: 'Track spending, categorize transactions, and watch your financial health improve with AI-driven recommendations.',
+  },
+  {
+    icon: BarChart3,
+    bg: 'bg-navy-50',
+    text: 'text-navy-600',
+    title: 'Smart Dashboard',
+    desc: 'Your health and finances visualized together. Discover how your spending affects your wellness and vice versa.',
+  },
+  {
+    icon: MessageCircle,
+    bg: 'bg-emerald-50',
+    text: 'text-emerald-600',
+    title: 'Conversational Assistant',
+    desc: 'Ask anything. "How was my sleep this week?" or "Where did most of my money go?" Get instant, intelligent answers.',
+  },
+  {
+    icon: Lock,
+    bg: 'bg-navy-50',
+    text: 'text-navy-600',
+    title: 'Private & Secure',
+    desc: 'Your data stays encrypted and private. We never sell your information. You own your data, period.',
+  },
+];
+
+const stats = [
+  { value: '1 dashboard', label: 'for health + finances' },
+  { value: 'NLP-powered', label: 'natural input' },
+  { value: 'Real-time', label: 'AI insights' },
+  { value: '100% private', label: 'your data' },
+];
+
+function NavBar() {
+  return (
+    <nav className="fixed top-0 inset-x-0 z-50 bg-white/80 backdrop-blur-xl border-b border-navy-100/60">
+      <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
+        <Link to="/" className="flex items-center gap-2.5">
+          <div className="w-8 h-8 rounded-xl bg-gradient-to-br from-emerald-400 to-emerald-600 flex items-center justify-center shadow-sm">
+            <Activity className="w-4 h-4 text-white" strokeWidth={2.5} />
+          </div>
+          <span className="font-display text-lg font-bold text-navy-900">LifeSync</span>
+        </Link>
+
+        <div className="flex items-center gap-3">
+          <Link
+            to="/login"
+            className="text-sm font-medium text-navy-600 hover:text-navy-900 px-4 py-2 rounded-lg hover:bg-navy-50 transition-all"
+          >
+            Sign in
+          </Link>
+          <Link
+            to="/register"
+            className="text-sm font-semibold text-white bg-gradient-to-r from-emerald-500 to-emerald-600 px-5 py-2 rounded-xl shadow-md shadow-emerald-500/20 hover:from-emerald-600 hover:to-emerald-700 transition-all"
+          >
+            Get started free
+          </Link>
+        </div>
+      </div>
+    </nav>
+  );
+}
+
+function HeroSection() {
+  return (
+    <section className="relative min-h-screen flex flex-col items-center justify-center overflow-hidden pt-16">
+      <div className="absolute inset-0 bg-gradient-to-br from-navy-950 via-navy-900 to-navy-800">
+        <div
+          className="absolute inset-0 opacity-20"
+          style={{
+            backgroundImage:
+              'radial-gradient(circle at 20% 50%, #10b981 0%, transparent 50%), radial-gradient(circle at 80% 20%, #34d399 0%, transparent 40%)',
+          }}
+        />
+        <div
+          className="absolute inset-0 opacity-[0.03]"
+          style={{
+            backgroundImage:
+              'linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px)',
+            backgroundSize: '48px 48px',
+          }}
+        />
+      </div>
+
+      <div
+        className="absolute top-1/4 left-1/4 w-96 h-96 rounded-full bg-emerald-500/10 blur-3xl animate-pulse"
+        style={{ animationDuration: '4s' }}
+      />
+      <div
+        className="absolute bottom-1/4 right-1/4 w-64 h-64 rounded-full bg-emerald-400/8 blur-3xl animate-pulse"
+        style={{ animationDuration: '6s', animationDelay: '2s' }}
+      />
+
+      <div className="relative z-10 text-center px-6 max-w-4xl mx-auto">
+        <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 text-sm font-medium mb-8">
+          <Sparkles className="w-3.5 h-3.5" />
+          AI-powered life management
+        </div>
+
+        <h1 className="font-display text-5xl sm:text-6xl lg:text-7xl font-bold text-white leading-[1.05] tracking-tight mb-6">
+          Your health and finances,
+          {' '}
+          <span className="text-transparent bg-clip-text bg-gradient-to-r from-emerald-400 to-emerald-300">
+            one conversation
+          </span>
+          {' '}
+          away.
+        </h1>
+
+        <p className="text-navy-300 text-lg sm:text-xl max-w-2xl mx-auto leading-relaxed mb-10">
+          LifeSync connects your wellness and financial data through natural language.
+          {' '}
+          Just talk. Our AI handles the rest.
+        </p>
+
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+          <Link
+            to="/register"
+            className="group flex items-center gap-2 px-8 py-4 rounded-2xl bg-gradient-to-r from-emerald-500 to-emerald-600 text-white font-semibold text-base shadow-xl shadow-emerald-500/25 hover:from-emerald-600 hover:to-emerald-700 hover:shadow-emerald-500/35 transition-all"
+          >
+            Get started free
+            <ArrowRight className="w-4 h-4 group-hover:translate-x-0.5 transition-transform" />
+          </Link>
+          <Link
+            to="/login"
+            className="flex items-center gap-2 px-8 py-4 rounded-2xl border border-navy-600 text-navy-300 font-medium text-base hover:border-navy-400 hover:text-white hover:bg-navy-800/50 transition-all"
+          >
+            Sign in
+          </Link>
+        </div>
+
+        <div className="mt-16 grid grid-cols-2 sm:grid-cols-4 gap-6 max-w-2xl mx-auto">
+          {stats.map((stat) => (
+            <div key={stat.label} className="text-center">
+              <div className="font-display font-bold text-xl text-white">{stat.value}</div>
+              <div className="text-navy-400 text-xs mt-0.5">{stat.label}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="absolute bottom-8 left-1/2 -translate-x-1/2 z-10 text-navy-500 flex flex-col items-center gap-1">
+        <span className="text-xs tracking-widest uppercase">Explore</span>
+        <ChevronDown className="w-4 h-4 animate-bounce" />
+      </div>
+    </section>
+  );
+}
+
+function FeaturesSection() {
+  return (
+    <section className="py-24 px-6 bg-surface">
+      <div className="max-w-6xl mx-auto">
+        <div className="text-center mb-16">
+          <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-emerald-50 text-emerald-600 text-sm font-medium mb-4">
+            <Zap className="w-3.5 h-3.5" />
+            Everything you need
+          </div>
+          <h2 className="font-display text-4xl font-bold text-navy-900 mb-4">
+            One app. Complete life picture.
+          </h2>
+          <p className="text-navy-500 text-lg max-w-xl mx-auto">
+            Stop juggling five apps. LifeSync brings your health and finances into a single intelligent dashboard.
+          </p>
+        </div>
+
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {features.map((feature) => (
+            <div
+              key={feature.title}
+              className="bg-white rounded-2xl p-6 border border-navy-100/60 hover:border-navy-200 hover:shadow-lg hover:shadow-navy-900/5 transition-all group"
+            >
+              <div className={`w-11 h-11 rounded-xl ${feature.bg} flex items-center justify-center mb-4 group-hover:scale-105 transition-transform`}>
+                <feature.icon className={`w-5 h-5 ${feature.text}`} />
+              </div>
+              <h3 className="font-display font-bold text-navy-900 mb-2">{feature.title}</h3>
+              <p className="text-navy-500 text-sm leading-relaxed">{feature.desc}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function HowItWorksSection() {
+  const steps = [
+    {
+      num: '01',
+      title: 'Create your account',
+      desc: 'Sign up with Google or email in seconds. No credit card and no commitments.',
+    },
+    {
+      num: '02',
+      title: 'Start logging naturally',
+      desc: 'Just type: "Ran 5k, feeling great" or "Spent $40 on groceries." LifeSync handles the categorization.',
+    },
+    {
+      num: '03',
+      title: 'Discover hidden patterns',
+      desc: 'Watch your dashboard reveal connections between your habits and finances you never noticed.',
+    },
+  ];
+
+  return (
+    <section className="py-24 px-6 bg-white border-y border-navy-100">
+      <div className="max-w-5xl mx-auto">
+        <div className="text-center mb-16">
+          <h2 className="font-display text-4xl font-bold text-navy-900 mb-4">
+            Simple by design
+          </h2>
+          <p className="text-navy-500 text-lg">Up and running in under 2 minutes.</p>
+        </div>
+
+        <div className="grid sm:grid-cols-3 gap-8">
+          {steps.map((step, index) => (
+            <div key={step.num} className="relative">
+              {index < steps.length - 1 && (
+                <div className="hidden sm:block absolute top-8 left-full w-full h-px bg-gradient-to-r from-emerald-200 to-transparent -z-0 translate-x-[-50%]" />
+              )}
+              <div className="relative z-10">
+                <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-navy-900 to-navy-800 flex items-center justify-center mb-5 shadow-lg">
+                  <span className="font-display font-bold text-emerald-400 text-sm">{step.num}</span>
+                </div>
+                <h3 className="font-display font-bold text-navy-900 mb-2">{step.title}</h3>
+                <p className="text-navy-500 text-sm leading-relaxed">{step.desc}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CTASection() {
+  return (
+    <section className="py-24 px-6 bg-gradient-to-br from-navy-950 via-navy-900 to-navy-800 relative overflow-hidden">
+      <div
+        className="absolute inset-0 opacity-15"
+        style={{ backgroundImage: 'radial-gradient(circle at 60% 50%, #10b981 0%, transparent 60%)' }}
+      />
+      <div className="relative z-10 max-w-2xl mx-auto text-center">
+        <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 text-sm font-medium mb-6">
+          <Star className="w-3.5 h-3.5" />
+          Free to get started
+        </div>
+        <h2 className="font-display text-4xl sm:text-5xl font-bold text-white mb-4 leading-tight">
+          Take control of your life today
+        </h2>
+        <p className="text-navy-300 text-lg mb-10">
+          Join the next generation of people who manage health and money intelligently.
+        </p>
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+          <Link
+            to="/register"
+            className="group flex items-center gap-2 px-8 py-4 rounded-2xl bg-gradient-to-r from-emerald-500 to-emerald-600 text-white font-semibold text-base shadow-xl shadow-emerald-500/25 hover:from-emerald-600 hover:to-emerald-700 transition-all"
+          >
+            Create free account
+            <ArrowRight className="w-4 h-4 group-hover:translate-x-0.5 transition-transform" />
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Footer() {
+  return (
+    <footer className="bg-navy-950 text-navy-400 px-6 py-10">
+      <div className="max-w-6xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
+        <div className="flex items-center gap-2.5">
+          <div className="w-7 h-7 rounded-lg bg-emerald-500/20 flex items-center justify-center">
+            <Activity className="w-4 h-4 text-emerald-400" strokeWidth={2.5} />
+          </div>
+          <span className="font-display font-bold text-white text-sm">LifeSync</span>
+          <span className="text-navy-600 text-xs ml-2">· Birzeit University Graduation Project</span>
+        </div>
+
+        <div className="flex items-center gap-6 text-sm">
+          <Link to="/privacy" className="hover:text-white transition-colors">Privacy Policy</Link>
+          <Link to="/terms" className="hover:text-white transition-colors">Terms of Service</Link>
+          <Link to="/login" className="hover:text-white transition-colors">Sign In</Link>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+export default function LandingPage() {
+  return (
+    <div className="min-h-screen">
+      <NavBar />
+      <HeroSection />
+      <FeaturesSection />
+      <HowItWorksSection />
+      <CTASection />
+      <Footer />
+    </div>
+  );
+}

--- a/client/src/pages/PrivacyPolicyPage.jsx
+++ b/client/src/pages/PrivacyPolicyPage.jsx
@@ -1,0 +1,240 @@
+import { Link } from 'react-router-dom';
+import { Activity, ArrowLeft, Shield, Lock, Eye, Trash2, Mail, Globe } from 'lucide-react';
+
+const LAST_UPDATED = 'March 2026';
+const CONTACT_EMAIL = 'lifesync.birzeit@gmail.com';
+const APP_NAME = 'LifeSync';
+const ORG_NAME = 'Birzeit University — LifeSync Project Team';
+
+function NavBar() {
+  return (
+    <nav className="sticky top-0 z-50 bg-white/90 backdrop-blur-lg border-b border-navy-100">
+      <div className="max-w-4xl mx-auto px-6 h-14 flex items-center justify-between">
+        <Link to="/" className="flex items-center gap-2">
+          <div className="w-7 h-7 rounded-lg bg-gradient-to-br from-emerald-400 to-emerald-600 flex items-center justify-center">
+            <Activity className="w-4 h-4 text-white" strokeWidth={2.5} />
+          </div>
+          <span className="font-display font-bold text-navy-900">{APP_NAME}</span>
+        </Link>
+        <Link
+          to="/"
+          className="flex items-center gap-1.5 text-sm text-navy-500 hover:text-navy-800 transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          {' '}
+          Back to home
+        </Link>
+      </div>
+    </nav>
+  );
+}
+
+function Section({ icon: Icon, title, children, id }) {
+  return (
+    <section id={id} className="mb-10">
+      <div className="flex items-center gap-3 mb-3">
+        <div className="w-8 h-8 rounded-lg bg-emerald-50 flex items-center justify-center flex-shrink-0">
+          <Icon className="w-4 h-4 text-emerald-600" />
+        </div>
+        <h2 className="font-display text-xl font-bold text-navy-900">{title}</h2>
+      </div>
+      <div className="text-navy-600 text-sm leading-7 space-y-3 pl-11">{children}</div>
+    </section>
+  );
+}
+
+function SectionTitle({ children }) {
+  return <h3 className="font-semibold text-navy-800 mt-4 mb-1">{children}</h3>;
+}
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="min-h-screen bg-surface">
+      <NavBar />
+
+      <div className="bg-gradient-to-br from-navy-900 to-navy-800 py-16 px-6 text-center">
+        <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 text-sm font-medium mb-4">
+          <Shield className="w-3.5 h-3.5" />
+          Your privacy matters
+        </div>
+        <h1 className="font-display text-4xl font-bold text-white mb-3">Privacy Policy</h1>
+        <p className="text-navy-300 text-sm">Last updated: {LAST_UPDATED}</p>
+      </div>
+
+      <div className="max-w-4xl mx-auto px-6 py-14">
+        <div className="bg-white rounded-2xl border border-navy-100 p-8 mb-10 shadow-sm">
+          <p className="text-navy-600 text-sm leading-7">
+            Welcome to
+            {' '}
+            <strong className="text-navy-900">{APP_NAME}</strong>
+            , developed by
+            {' '}
+            <strong className="text-navy-900">{ORG_NAME}</strong>
+            . This Privacy Policy explains how we collect, use, disclose, and protect your personal information when you use our application.
+            By creating an account or using
+            {' '}
+            {APP_NAME}
+            , you agree to the practices described in this policy.
+          </p>
+          <p className="text-navy-500 text-xs mt-3">
+            If you have questions, email us at
+            {' '}
+            <a href={`mailto:${CONTACT_EMAIL}`} className="text-emerald-600 underline">{CONTACT_EMAIL}</a>
+            .
+          </p>
+        </div>
+
+        <div className="bg-white rounded-2xl border border-navy-100 p-8 shadow-sm space-y-2">
+          <Section icon={Eye} title="1. Information We Collect" id="collect">
+            <SectionTitle>Account Information</SectionTitle>
+            <p>When you register, we collect your email address, username, and optionally your full name and profile picture. If you sign in with Google, we receive your Google profile information such as name, email, and profile photo from Google&apos;s OAuth service.</p>
+
+            <SectionTitle>Health Data</SectionTitle>
+            <p>We collect health-related information you choose to log, including step counts, sleep duration, mood ratings, water intake, nutrition, and exercise records. This data is entered voluntarily by you.</p>
+
+            <SectionTitle>Financial Data</SectionTitle>
+            <p>We collect financial transaction information you manually enter or log through our natural language interface, including amounts, categories, and descriptions. We do not connect to your bank accounts or payment providers.</p>
+
+            <SectionTitle>Usage &amp; Technical Data</SectionTitle>
+            <p>We automatically collect limited technical information including your IP address for security and rate limiting, browser type, operating system, and usage patterns to improve the service.</p>
+
+            <SectionTitle>Chat &amp; AI Interactions</SectionTitle>
+            <p>Conversations with our AI assistant may be stored to provide context and continuity. These messages are used to generate insights and improve your in-app experience.</p>
+          </Section>
+
+          <Section icon={Globe} title="2. How We Use Your Information" id="use">
+            <p>We use your information to:</p>
+            <ul className="list-disc list-inside space-y-1.5 mt-2">
+              <li>Provide, personalize, and improve the {APP_NAME} service</li>
+              <li>Generate AI-powered health and financial insights tailored to you</li>
+              <li>Authenticate your identity and keep your account secure</li>
+              <li>Send transactional emails such as OTP codes and account alerts</li>
+              <li>Analyze aggregate, anonymized usage patterns to improve the product</li>
+              <li>Comply with legal obligations</li>
+            </ul>
+            <p className="mt-3">
+              We do
+              {' '}
+              <strong>not</strong>
+              {' '}
+              use your data for advertising, and we do not sell your personal information to third parties.
+            </p>
+          </Section>
+
+          <Section icon={Shield} title="3. Google Sign-In & OAuth" id="google">
+            <p>
+              {APP_NAME}
+              {' '}
+              offers Sign in with Google using Google&apos;s OAuth 2.0 service. When you authenticate with Google, we receive:
+            </p>
+            <ul className="list-disc list-inside space-y-1 mt-2">
+              <li>Your Google account email address</li>
+              <li>Your display name</li>
+              <li>Your Google profile picture URL</li>
+              <li>A unique Google user ID</li>
+            </ul>
+            <p className="mt-3">We do not receive your Google password, access to your Google Drive, Gmail, or any other Google services. The only data we access is the profile information listed above.</p>
+            <p className="mt-3">
+              Your Google credentials are never stored on our servers. We verify the authenticity of your Google ID token and then issue our own JWT session tokens.
+              {' '}
+              <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer" className="text-emerald-600 underline">Google&apos;s Privacy Policy</a>
+              {' '}
+              governs Google&apos;s handling of your data.
+            </p>
+          </Section>
+
+          <Section icon={Lock} title="4. Data Sharing & Third Parties" id="sharing">
+            <p>We share your data only with the following third parties, solely to operate the service:</p>
+            <ul className="list-disc list-inside space-y-1.5 mt-2">
+              <li><strong>Railway</strong> — backend hosting and database infrastructure</li>
+              <li><strong>Cloudflare</strong> — frontend hosting and content delivery</li>
+              <li><strong>Firebase (Google)</strong> — real-time chat message synchronization</li>
+              <li><strong>DeepSeek</strong> — our intended AI provider for natural-language logging and generated summaries</li>
+              <li><strong>Compatible fallback AI provider</strong> — may be used temporarily during migration if explicitly configured by deployment administrators</li>
+              <li><strong>Nodemailer / SMTP provider</strong> — transactional email delivery such as OTP codes</li>
+            </ul>
+            <p className="mt-3">We do not share your personal information with advertisers or data brokers.</p>
+          </Section>
+
+          <Section icon={Lock} title="5. Data Security" id="security">
+            <p>We take data security seriously and implement protections including:</p>
+            <ul className="list-disc list-inside space-y-1.5 mt-2">
+              <li>Passwords are hashed using bcrypt before storage and are never stored in plaintext</li>
+              <li>API communication is encrypted via HTTPS/TLS</li>
+              <li>Authentication uses short-lived JWT access tokens with refresh token rotation</li>
+              <li>Sensitive fields in the database are encrypted at rest</li>
+              <li>Rate limiting protects against brute-force attacks</li>
+              <li>Email verification is required for new local accounts</li>
+            </ul>
+            <p className="mt-3">While we take reasonable measures, no system is 100% secure. Please use a strong, unique password or Google Sign-In for stronger account protection.</p>
+          </Section>
+
+          <Section icon={Trash2} title="6. Data Retention & Deletion" id="retention">
+            <p>
+              We retain your account and associated data for as long as your account is active or as needed to provide the service. You may request deletion of your account through profile settings or by contacting
+              {' '}
+              <a href={`mailto:${CONTACT_EMAIL}`} className="text-emerald-600 underline">{CONTACT_EMAIL}</a>
+              .
+            </p>
+            <p className="mt-3">Upon account deletion, we will permanently delete your personal data within a reasonable time except where retention is required by law or for legitimate security purposes such as fraud prevention records.</p>
+          </Section>
+
+          <Section icon={Eye} title="7. Your Rights" id="rights">
+            <p>Depending on your jurisdiction, you may have the following rights:</p>
+            <ul className="list-disc list-inside space-y-1.5 mt-2">
+              <li><strong>Access</strong> — request a copy of the personal data we hold about you</li>
+              <li><strong>Correction</strong> — request correction of inaccurate data</li>
+              <li><strong>Deletion</strong> — request deletion of your personal data</li>
+              <li><strong>Portability</strong> — request your data in a portable format</li>
+              <li><strong>Objection</strong> — object to certain types of processing</li>
+            </ul>
+            <p className="mt-3">
+              To exercise any of these rights, contact us at
+              {' '}
+              <a href={`mailto:${CONTACT_EMAIL}`} className="text-emerald-600 underline">{CONTACT_EMAIL}</a>
+              .
+            </p>
+          </Section>
+
+          <Section icon={Shield} title="8. Children&apos;s Privacy" id="children">
+            <p>{APP_NAME} is not intended for use by children under 13 years of age. We do not knowingly collect personal information from children under 13. If you believe we have inadvertently collected such data, contact us immediately and we will delete it.</p>
+          </Section>
+
+          <Section icon={Globe} title="9. Changes to This Policy" id="changes">
+            <p>We may update this Privacy Policy from time to time. When we do, we will update the last updated date at the top of this page. For material changes, we will notify you via email or in-app messaging where practical. Continued use of {APP_NAME} after changes are posted constitutes your acceptance of the revised policy.</p>
+          </Section>
+
+          <Section icon={Mail} title="10. Contact Us" id="contact">
+            <p>If you have questions, concerns, or requests regarding this Privacy Policy or our data practices, please contact:</p>
+            <div className="mt-3 p-4 rounded-xl bg-navy-50 border border-navy-100">
+              <p className="font-semibold text-navy-800">{ORG_NAME}</p>
+              <p>
+                Email:
+                {' '}
+                <a href={`mailto:${CONTACT_EMAIL}`} className="text-emerald-600 underline">{CONTACT_EMAIL}</a>
+              </p>
+              <p>Birzeit, West Bank, Palestine</p>
+            </div>
+          </Section>
+        </div>
+      </div>
+
+      <footer className="bg-navy-950 text-navy-400 py-8 px-6 text-center text-sm">
+        <p>
+          &copy;
+          {' '}
+          {new Date().getFullYear()}
+          {' '}
+          {ORG_NAME}
+          {' '}
+          · All rights reserved
+        </p>
+        <div className="flex justify-center gap-6 mt-3">
+          <Link to="/" className="hover:text-white transition-colors">Home</Link>
+          <Link to="/terms" className="hover:text-white transition-colors">Terms of Service</Link>
+          <Link to="/login" className="hover:text-white transition-colors">Sign In</Link>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/client/src/pages/TermsPage.jsx
+++ b/client/src/pages/TermsPage.jsx
@@ -1,0 +1,217 @@
+import { Link } from 'react-router-dom';
+import {
+  Activity,
+  ArrowLeft,
+  FileText,
+  AlertCircle,
+  CheckCircle,
+  XCircle,
+  Scale,
+  Mail,
+} from 'lucide-react';
+
+const LAST_UPDATED = 'March 2026';
+const CONTACT_EMAIL = 'lifesync.birzeit@gmail.com';
+const APP_NAME = 'LifeSync';
+const ORG_NAME = 'Birzeit University — LifeSync Project Team';
+
+function NavBar() {
+  return (
+    <nav className="sticky top-0 z-50 bg-white/90 backdrop-blur-lg border-b border-navy-100">
+      <div className="max-w-4xl mx-auto px-6 h-14 flex items-center justify-between">
+        <Link to="/" className="flex items-center gap-2">
+          <div className="w-7 h-7 rounded-lg bg-gradient-to-br from-emerald-400 to-emerald-600 flex items-center justify-center">
+            <Activity className="w-4 h-4 text-white" strokeWidth={2.5} />
+          </div>
+          <span className="font-display font-bold text-navy-900">{APP_NAME}</span>
+        </Link>
+        <Link to="/" className="flex items-center gap-1.5 text-sm text-navy-500 hover:text-navy-800 transition-colors">
+          <ArrowLeft className="w-4 h-4" />
+          {' '}
+          Back to home
+        </Link>
+      </div>
+    </nav>
+  );
+}
+
+function Section({ icon: Icon, title, children, id }) {
+  return (
+    <section id={id} className="mb-10">
+      <div className="flex items-center gap-3 mb-3">
+        <div className="w-8 h-8 rounded-lg bg-navy-50 flex items-center justify-center flex-shrink-0">
+          <Icon className="w-4 h-4 text-navy-600" />
+        </div>
+        <h2 className="font-display text-xl font-bold text-navy-900">{title}</h2>
+      </div>
+      <div className="text-navy-600 text-sm leading-7 space-y-3 pl-11">{children}</div>
+    </section>
+  );
+}
+
+function SectionTitle({ children }) {
+  return <h3 className="font-semibold text-navy-800 mt-4 mb-1">{children}</h3>;
+}
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-surface">
+      <NavBar />
+
+      <div className="bg-gradient-to-br from-navy-900 to-navy-800 py-16 px-6 text-center">
+        <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-navy-700/60 border border-navy-600 text-navy-300 text-sm font-medium mb-4">
+          <Scale className="w-3.5 h-3.5" />
+          Legal agreement
+        </div>
+        <h1 className="font-display text-4xl font-bold text-white mb-3">Terms of Service</h1>
+        <p className="text-navy-300 text-sm">Last updated: {LAST_UPDATED}</p>
+      </div>
+
+      <div className="max-w-4xl mx-auto px-6 py-14">
+        <div className="bg-white rounded-2xl border border-navy-100 p-8 mb-10 shadow-sm">
+          <p className="text-navy-600 text-sm leading-7">
+            These Terms of Service govern your access to and use of
+            {' '}
+            <strong className="text-navy-900">{APP_NAME}</strong>
+            , operated by
+            {' '}
+            <strong className="text-navy-900">{ORG_NAME}</strong>
+            . By creating an account or using
+            {' '}
+            {APP_NAME}
+            , you agree to be bound by these Terms.
+          </p>
+          <div className="mt-4 p-4 rounded-xl bg-amber-50 border border-amber-200 flex gap-3">
+            <AlertCircle className="w-5 h-5 text-amber-500 flex-shrink-0 mt-0.5" />
+            <p className="text-amber-700 text-sm">
+              <strong>Academic Project Notice:</strong>
+              {' '}
+              {APP_NAME}
+              {' '}
+              is a graduation project developed at Birzeit University. It is provided as-is for educational and demonstration purposes and is not a regulated commercial service.
+            </p>
+          </div>
+        </div>
+
+        <div className="bg-white rounded-2xl border border-navy-100 p-8 shadow-sm">
+          <Section icon={CheckCircle} title="1. Acceptance of Terms" id="acceptance">
+            <p>By accessing or using {APP_NAME}, you confirm that you are at least 13 years old, have read and understood these Terms, and agree to be bound by them. If you do not agree, you must not use the service.</p>
+            <p>We may update these Terms from time to time. Continued use of {APP_NAME} after changes are posted constitutes your acceptance of the revised Terms.</p>
+          </Section>
+
+          <Section icon={FileText} title="2. Account Registration" id="account">
+            <SectionTitle>Creating an Account</SectionTitle>
+            <p>To use {APP_NAME}, you must create an account by providing a valid email address or signing in with Google and choosing a username. You are responsible for maintaining the confidentiality of your login credentials.</p>
+
+            <SectionTitle>Account Responsibility</SectionTitle>
+            <p>You are responsible for all activity that occurs under your account. You agree to notify us immediately of any unauthorized access. We are not liable for losses arising from unauthorized use of your account.</p>
+
+            <SectionTitle>Accurate Information</SectionTitle>
+            <p>You agree to provide accurate and complete information during registration and to keep it up to date.</p>
+          </Section>
+
+          <Section icon={CheckCircle} title="3. Acceptable Use" id="acceptable-use">
+            <p>You agree to use {APP_NAME} only for lawful purposes. You must not:</p>
+            <ul className="list-disc list-inside space-y-1.5 mt-2">
+              <li>Violate any applicable law or regulation</li>
+              <li>Attempt to gain unauthorized access to any part of the service or its infrastructure</li>
+              <li>Introduce malware, viruses, or malicious code</li>
+              <li>Use the service to harass, abuse, or harm others</li>
+              <li>Scrape, crawl, or systematically extract data from the service</li>
+              <li>Reverse-engineer or attempt to derive the source code of the service</li>
+              <li>Use the service for commercial purposes without our express written permission</li>
+              <li>Create multiple accounts to circumvent restrictions</li>
+            </ul>
+          </Section>
+
+          <Section icon={AlertCircle} title="4. Health & Financial Data Disclaimer" id="disclaimer">
+            <div className="p-4 rounded-xl bg-coral-50 border border-coral-200 flex gap-3">
+              <AlertCircle className="w-5 h-5 text-coral-500 flex-shrink-0 mt-0.5" />
+              <p className="text-coral-700 text-sm">
+                <strong>Important:</strong>
+                {' '}
+                {APP_NAME}
+                {' '}
+                is not a medical service, financial advisor, or regulated health application.
+              </p>
+            </div>
+            <p className="mt-3">The health tracking, financial analysis, and AI-generated insights provided by {APP_NAME} are for informational and personal tracking purposes only. They are not medical advice, diagnoses, treatment recommendations, or financial advice.</p>
+            <p>Always consult a qualified healthcare professional, doctor, or licensed financial advisor before making decisions based on information in the app. {APP_NAME} and its creators are not liable for health or financial decisions made based on the service.</p>
+          </Section>
+
+          <Section icon={Scale} title="5. Intellectual Property" id="ip">
+            <SectionTitle>Our Content</SectionTitle>
+            <p>The {APP_NAME} application, including its design, code, branding, and AI features, is the intellectual property of {ORG_NAME}. Nothing in these Terms grants you ownership of any part of the service.</p>
+
+            <SectionTitle>Your Content</SectionTitle>
+            <p>You retain ownership of all personal data and content you input into {APP_NAME}, such as health logs, financial records, and chat messages. By using the service, you grant us a limited, non-exclusive license to process and store your content solely to provide the service to you.</p>
+          </Section>
+
+          <Section icon={FileText} title="6. Privacy" id="privacy">
+            <p>
+              Your use of
+              {' '}
+              {APP_NAME}
+              {' '}
+              is also governed by our
+              {' '}
+              <Link to="/privacy" className="text-emerald-600 underline font-medium">Privacy Policy</Link>
+              , which is incorporated into these Terms by reference.
+            </p>
+          </Section>
+
+          <Section icon={XCircle} title="7. Limitation of Liability" id="liability">
+            <p>To the fullest extent permitted by applicable law, {APP_NAME} and {ORG_NAME} shall not be liable for indirect, incidental, special, consequential, or punitive damages arising from your use of or inability to use the service, including any loss of data, health decisions, or financial decisions.</p>
+            <p>The service is provided <strong>as is</strong> and <strong>as available</strong> without warranties of any kind, whether express or implied, including merchantability, fitness for a particular purpose, or non-infringement.</p>
+            <p>Since {APP_NAME} is an academic project, we provide no service-level guarantees, uptime commitments, or support obligations.</p>
+          </Section>
+
+          <Section icon={XCircle} title="8. Termination" id="termination">
+            <p>We reserve the right to suspend or terminate your account at any time for violation of these Terms, illegal activity, or at our discretion, without prior notice.</p>
+            <p>
+              You may delete your account through profile settings or by contacting
+              {' '}
+              <a href={`mailto:${CONTACT_EMAIL}`} className="text-emerald-600 underline">{CONTACT_EMAIL}</a>
+              . Upon termination, your data will be handled per our Privacy Policy.
+            </p>
+          </Section>
+
+          <Section icon={Scale} title="9. Governing Law" id="governing-law">
+            <p>These Terms shall be governed by and construed in accordance with the laws applicable in the jurisdiction of Birzeit University, West Bank, Palestine, without regard to conflict of law principles.</p>
+            <p>Any disputes arising from these Terms or your use of {APP_NAME} should first be attempted to be resolved informally by contacting us.</p>
+          </Section>
+
+          <Section icon={Mail} title="10. Contact" id="contact">
+            <p>For questions about these Terms, please contact us:</p>
+            <div className="mt-3 p-4 rounded-xl bg-navy-50 border border-navy-100">
+              <p className="font-semibold text-navy-800">{ORG_NAME}</p>
+              <p>
+                Email:
+                {' '}
+                <a href={`mailto:${CONTACT_EMAIL}`} className="text-emerald-600 underline">{CONTACT_EMAIL}</a>
+              </p>
+              <p>Birzeit, West Bank, Palestine</p>
+            </div>
+          </Section>
+        </div>
+      </div>
+
+      <footer className="bg-navy-950 text-navy-400 py-8 px-6 text-center text-sm">
+        <p>
+          &copy;
+          {' '}
+          {new Date().getFullYear()}
+          {' '}
+          {ORG_NAME}
+          {' '}
+          · All rights reserved
+        </p>
+        <div className="flex justify-center gap-6 mt-3">
+          <Link to="/" className="hover:text-white transition-colors">Home</Link>
+          <Link to="/privacy" className="hover:text-white transition-colors">Privacy Policy</Link>
+          <Link to="/login" className="hover:text-white transition-colors">Sign In</Link>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -25,9 +25,13 @@
 
   --color-coral-400: #fb7185;
   --color-coral-500: #f43f5e;
+  --color-coral-50: #fff1f2;
+  --color-coral-200: #fecdd3;
 
   --color-amber-400: #fbbf24;
   --color-amber-500: #f59e0b;
+  --color-amber-50: #fffbeb;
+  --color-amber-200: #fde68a;
 
   --color-surface: #f8fafc;
   --color-surface-raised: #ffffff;

--- a/server/services/ai/insightsService.js
+++ b/server/services/ai/insightsService.js
@@ -1,7 +1,7 @@
 // server/services/ai/insightsService.js
 // ============================================
 // Insights Service
-// Gathers weekly data and generates AI-powered summaries
+// Gathers weekly data and generates model-backed summaries
 // ============================================
 
 const { Op } = require('sequelize');
@@ -57,7 +57,7 @@ const generateAndStoreInsights = async (userId) => {
     nest: true,
   });
 
-  // Call OpenAI to analyze
+  // Call the configured AI provider to analyze
   const insights = await generateWeeklyInsights(
     { metrics: healthData, period: { start: weekAgo, end: now } },
     { transactions: financeData, period: { start: weekAgo, end: now } }

--- a/server/services/ai/nlpService.js
+++ b/server/services/ai/nlpService.js
@@ -1,6 +1,6 @@
 // server/services/ai/nlpService.js
 // ============================================
-// NLP Service v2 — OpenAI Integration
+// NLP Service v2 — AI Provider Integration
 // Enhanced with:
 //   - Strict entity extraction (Amount, Category, Duration, Activity)
 //   - Auto-classification (Health vs. Finance)
@@ -8,24 +8,8 @@
 //   - Conversation context awareness
 // ============================================
 
-const OpenAI = require('openai');
 require('dotenv').config();
-
-let openaiClient = null;
-
-const getOpenAIClient = () => {
-  if (!process.env.OPENAI_API_KEY) {
-    throw new Error('OpenAI API key is not configured.');
-  }
-
-  if (!openaiClient) {
-    openaiClient = new OpenAI({
-      apiKey: process.env.OPENAI_API_KEY,
-    });
-  }
-
-  return openaiClient;
-};
+const { getAIClient, getAIModel } = require('./providerClient');
 
 // ============================================
 // SYSTEM PROMPT — Core NLP Instructions
@@ -162,7 +146,7 @@ Parse this in context of the original message. Extract full entities now that am
 };
 
 /**
- * Parse a natural language message using OpenAI
+ * Parse a natural language message using the configured AI provider
  * @param {string} message - The user's input
  * @param {Object|null} pendingClarification - Previous clarification context
  * @returns {Object} Parsed result
@@ -182,8 +166,8 @@ const parseMessage = async (message, pendingClarification = null) => {
       messages.push({ role: 'user', content: message });
     }
 
-    const completion = await getOpenAIClient().chat.completions.create({
-      model: process.env.OPENAI_MODEL || 'gpt-4o-mini',
+    const completion = await getAIClient().chat.completions.create({
+      model: getAIModel(),
       messages,
       temperature: 0.05,
       max_tokens: 1000,
@@ -193,7 +177,7 @@ const parseMessage = async (message, pendingClarification = null) => {
     const rawResponse = completion.choices[0]?.message?.content;
     const processingTime = Date.now() - startTime;
 
-    if (!rawResponse) throw new Error('Empty response from OpenAI');
+    if (!rawResponse) throw new Error('Empty response from AI provider');
 
     let parsed;
     try {
@@ -360,8 +344,8 @@ Respond ONLY with valid JSON:
   "financial_health_score": <1-100>
 }`;
 
-    const completion = await getOpenAIClient().chat.completions.create({
-      model: process.env.OPENAI_MODEL || 'gpt-4o-mini',
+    const completion = await getAIClient().chat.completions.create({
+      model: getAIModel(),
       messages: [
         {
           role: 'system',

--- a/server/services/ai/providerClient.js
+++ b/server/services/ai/providerClient.js
@@ -1,0 +1,85 @@
+const OpenAI = require('openai');
+require('dotenv').config();
+
+const SUPPORTED_PROVIDERS = new Set(['deepseek', 'openai']);
+let cachedClient = null;
+
+const normalizeProvider = (value) => value?.trim().toLowerCase() || '';
+
+const resolveAIProvider = () => {
+  const configuredProvider = normalizeProvider(process.env.AI_PROVIDER);
+  if (configuredProvider) {
+    if (!SUPPORTED_PROVIDERS.has(configuredProvider)) {
+      throw new Error(`Unsupported AI provider: ${process.env.AI_PROVIDER}`);
+    }
+    return configuredProvider;
+  }
+
+  if (process.env.DEEPSEEK_API_KEY) return 'deepseek';
+  if (process.env.OPENAI_API_KEY) return 'openai';
+  return 'deepseek';
+};
+
+const getProviderSettings = () => {
+  const provider = resolveAIProvider();
+
+  if (provider === 'deepseek') {
+    const apiKey = process.env.DEEPSEEK_API_KEY || '';
+    return {
+      provider,
+      apiKey,
+      model: process.env.DEEPSEEK_MODEL || 'deepseek-chat',
+      clientOptions: {
+        apiKey,
+        baseURL: 'https://api.deepseek.com',
+      },
+    };
+  }
+
+  return {
+    provider,
+    apiKey: process.env.OPENAI_API_KEY || '',
+    model: process.env.OPENAI_MODEL || 'gpt-4o-mini',
+    clientOptions: {
+      apiKey: process.env.OPENAI_API_KEY || '',
+    },
+  };
+};
+
+const getAIClient = () => {
+  const settings = getProviderSettings();
+
+  if (!settings.apiKey) {
+    const providerName = settings.provider === 'deepseek' ? 'DeepSeek' : 'OpenAI';
+    throw new Error(`${providerName} API key is not configured.`);
+  }
+
+  const signature = JSON.stringify({
+    provider: settings.provider,
+    apiKey: settings.apiKey,
+    model: settings.model,
+  });
+
+  if (!cachedClient || cachedClient.signature !== signature) {
+    cachedClient = {
+      signature,
+      client: new OpenAI(settings.clientOptions),
+    };
+  }
+
+  return cachedClient.client;
+};
+
+const getAIModel = () => getProviderSettings().model;
+
+const resetAIClient = () => {
+  cachedClient = null;
+};
+
+module.exports = {
+  getAIClient,
+  getAIModel,
+  _resolveAIProvider: resolveAIProvider,
+  _getProviderSettings: getProviderSettings,
+  _resetAIClient: resetAIClient,
+};

--- a/tests/providerClient.test.js
+++ b/tests/providerClient.test.js
@@ -1,0 +1,66 @@
+const {
+  _resolveAIProvider,
+  _getProviderSettings,
+} = require('../server/services/ai/providerClient');
+
+describe('providerClient', () => {
+  const originalEnv = {
+    AI_PROVIDER: process.env.AI_PROVIDER,
+    DEEPSEEK_API_KEY: process.env.DEEPSEEK_API_KEY,
+    DEEPSEEK_MODEL: process.env.DEEPSEEK_MODEL,
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    OPENAI_MODEL: process.env.OPENAI_MODEL,
+  };
+
+  afterEach(() => {
+    Object.entries(originalEnv).forEach(([key, value]) => {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    });
+  });
+
+  test('prefers explicit deepseek provider configuration', () => {
+    process.env.AI_PROVIDER = 'deepseek';
+    process.env.DEEPSEEK_API_KEY = 'ds-test';
+    process.env.DEEPSEEK_MODEL = 'deepseek-chat';
+    process.env.OPENAI_API_KEY = 'sk-test';
+
+    expect(_resolveAIProvider()).toBe('deepseek');
+
+    const settings = _getProviderSettings();
+    expect(settings.provider).toBe('deepseek');
+    expect(settings.model).toBe('deepseek-chat');
+    expect(settings.clientOptions.baseURL).toBe('https://api.deepseek.com');
+  });
+
+  test('falls back to openai when only openai is configured', () => {
+    delete process.env.AI_PROVIDER;
+    delete process.env.DEEPSEEK_API_KEY;
+    process.env.OPENAI_API_KEY = 'sk-test';
+    process.env.OPENAI_MODEL = 'gpt-4o-mini';
+
+    expect(_resolveAIProvider()).toBe('openai');
+
+    const settings = _getProviderSettings();
+    expect(settings.provider).toBe('openai');
+    expect(settings.model).toBe('gpt-4o-mini');
+    expect(settings.clientOptions.baseURL).toBeUndefined();
+  });
+
+  test('defaults to deepseek when no provider is configured', () => {
+    delete process.env.AI_PROVIDER;
+    delete process.env.DEEPSEEK_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+
+    expect(_resolveAIProvider()).toBe('deepseek');
+  });
+
+  test('throws for unsupported provider names', () => {
+    process.env.AI_PROVIDER = 'anthropic';
+
+    expect(() => _resolveAIProvider()).toThrow('Unsupported AI provider');
+  });
+});


### PR DESCRIPTION
## Summary
- add public landing, privacy, and terms pages and merge the public-route behavior into the existing app shell
- add a backend AI provider layer so chat and model-backed summaries can use DeepSeek without changing controller contracts
- update docs, config examples, and tests for the new public pages and AI provider selection

## Frontend
- add `LandingPage`, `PrivacyPolicyPage`, and `TermsPage`
- make `/` render the landing page for guests and redirect authenticated users to `/dashboard`
- add always-public `/privacy` and `/terms`
- keep all existing protected routes and the current `NotFoundPage` fallback unchanged
- add missing coral/amber theme tokens used by the public-page designs
- update privacy/terms copy to match the real project state and current account-deletion flow

## Backend
- add `server/services/ai/providerClient.js`
- route `nlpService` and `insightsService` through a provider abstraction
- support `AI_PROVIDER=deepseek` with `DEEPSEEK_API_KEY` and `DEEPSEEK_MODEL`
- keep OpenAI compatibility as an explicit fallback during migration so production does not break if DeepSeek env vars are not set yet
- remove the code path that was tied directly to OpenAI-specific client creation

## Validation
- `npm --prefix client run build`
- `NODE_ENV=test JWT_SECRET=test_jwt_secret_for_ci_pipeline_32ch JWT_REFRESH_SECRET=test_refresh_secret_for_ci_pipe ENCRYPTION_KEY=12345678901234567890123456789012 AI_PROVIDER=deepseek DEEPSEEK_API_KEY=ds-test npm test`
- backend tests passing: 118/118
- frontend production build passing

## Deploy notes
- Cloudflare can deploy the frontend pages from the merged `main` branch as usual
- Railway will pick up the provider-layer code from `main`, but live DeepSeek usage still requires a real `DEEPSEEK_API_KEY` in Railway env
- until the actual DeepSeek key is set, the backend can continue using the legacy OpenAI fallback if that env is still present