### PR TITLE
Make production AI provider DeepSeek-only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,15 +30,10 @@ JWT_REFRESH_SECRET=your_refresh_secret_key
 JWT_REFRESH_EXPIRES_IN=30d
 
 # --- AI Provider ---
-# Defaults to DeepSeek when DEEPSEEK_API_KEY is present.
+# Production chat and model-backed summaries require DeepSeek.
 AI_PROVIDER=deepseek
 DEEPSEEK_API_KEY=your_deepseek_api_key
 DEEPSEEK_MODEL=deepseek-chat
-
-# --- Legacy OpenAI Fallback (optional) ---
-# Keep only if you still want a fallback provider during migration.
-OPENAI_API_KEY=
-OPENAI_MODEL=gpt-4o-mini
 
 # --- Encryption ---
 ENCRYPTION_KEY=your_encryption_key_min_32_chars!

--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ npm run build
 ## Environment Notes
 
 - `DEEPSEEK_API_KEY` is required for live chat parsing and model-backed summaries when `AI_PROVIDER=deepseek`.
-- If you keep `OPENAI_API_KEY`, the backend can still use OpenAI as a temporary fallback until you finish the migration.
 - Firebase is optional. If it is not configured, Firebase-backed chat sync is skipped.
 - SMTP is optional in development. In production, use a real provider.
 - For Gmail SMTP, set `SMTP_HOST=smtp.gmail.com`, `SMTP_PORT=587`, `SMTP_SECURE=false`, and set `SMTP_FROM_EMAIL` to the same Gmail address as `SMTP_USER`.

--- a/client/src/pages/PrivacyPolicyPage.jsx
+++ b/client/src/pages/PrivacyPolicyPage.jsx
@@ -165,8 +165,7 @@ export default function PrivacyPolicyPage() {
               <li><strong>Railway</strong> — backend hosting and database infrastructure</li>
               <li><strong>Cloudflare</strong> — frontend hosting and content delivery</li>
               <li><strong>Firebase (Google)</strong> — real-time chat message synchronization</li>
-              <li><strong>DeepSeek</strong> — our intended AI provider for natural-language logging and generated summaries</li>
-              <li><strong>Compatible fallback AI provider</strong> — may be used temporarily during migration if explicitly configured by deployment administrators</li>
+              <li><strong>DeepSeek</strong> — AI language processing for natural-language logging and generated summaries</li>
               <li><strong>Nodemailer / SMTP provider</strong> — transactional email delivery such as OTP codes</li>
             </ul>
             <p className="mt-3">We do not share your personal information with advertisers or data brokers.</p>

--- a/server/services/ai/providerClient.js
+++ b/server/services/ai/providerClient.js
@@ -1,47 +1,34 @@
 const OpenAI = require('openai');
 require('dotenv').config();
 
-const SUPPORTED_PROVIDERS = new Set(['deepseek', 'openai']);
 let cachedClient = null;
 
 const normalizeProvider = (value) => value?.trim().toLowerCase() || '';
 
 const resolveAIProvider = () => {
   const configuredProvider = normalizeProvider(process.env.AI_PROVIDER);
-  if (configuredProvider) {
-    if (!SUPPORTED_PROVIDERS.has(configuredProvider)) {
-      throw new Error(`Unsupported AI provider: ${process.env.AI_PROVIDER}`);
-    }
-    return configuredProvider;
+
+  if (!configuredProvider) {
+    return 'deepseek';
   }
 
-  if (process.env.DEEPSEEK_API_KEY) return 'deepseek';
-  if (process.env.OPENAI_API_KEY) return 'openai';
+  if (configuredProvider !== 'deepseek') {
+    throw new Error(`Unsupported AI provider: ${process.env.AI_PROVIDER}`);
+  }
+
   return 'deepseek';
 };
 
 const getProviderSettings = () => {
-  const provider = resolveAIProvider();
-
-  if (provider === 'deepseek') {
-    const apiKey = process.env.DEEPSEEK_API_KEY || '';
-    return {
-      provider,
-      apiKey,
-      model: process.env.DEEPSEEK_MODEL || 'deepseek-chat',
-      clientOptions: {
-        apiKey,
-        baseURL: 'https://api.deepseek.com',
-      },
-    };
-  }
+  const apiKey = process.env.DEEPSEEK_API_KEY || '';
 
   return {
-    provider,
-    apiKey: process.env.OPENAI_API_KEY || '',
-    model: process.env.OPENAI_MODEL || 'gpt-4o-mini',
+    provider: resolveAIProvider(),
+    apiKey,
+    model: process.env.DEEPSEEK_MODEL || 'deepseek-chat',
     clientOptions: {
-      apiKey: process.env.OPENAI_API_KEY || '',
+      apiKey,
+      baseURL: 'https://api.deepseek.com',
     },
   };
 };
@@ -50,8 +37,7 @@ const getAIClient = () => {
   const settings = getProviderSettings();
 
   if (!settings.apiKey) {
-    const providerName = settings.provider === 'deepseek' ? 'DeepSeek' : 'OpenAI';
-    throw new Error(`${providerName} API key is not configured.`);
+    throw new Error('DeepSeek API key is not configured.');
   }
 
   const signature = JSON.stringify({

--- a/tests/providerClient.test.js
+++ b/tests/providerClient.test.js
@@ -8,8 +8,6 @@ describe('providerClient', () => {
     AI_PROVIDER: process.env.AI_PROVIDER,
     DEEPSEEK_API_KEY: process.env.DEEPSEEK_API_KEY,
     DEEPSEEK_MODEL: process.env.DEEPSEEK_MODEL,
-    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
-    OPENAI_MODEL: process.env.OPENAI_MODEL,
   };
 
   afterEach(() => {
@@ -26,7 +24,6 @@ describe('providerClient', () => {
     process.env.AI_PROVIDER = 'deepseek';
     process.env.DEEPSEEK_API_KEY = 'ds-test';
     process.env.DEEPSEEK_MODEL = 'deepseek-chat';
-    process.env.OPENAI_API_KEY = 'sk-test';
 
     expect(_resolveAIProvider()).toBe('deepseek');
 
@@ -36,30 +33,14 @@ describe('providerClient', () => {
     expect(settings.clientOptions.baseURL).toBe('https://api.deepseek.com');
   });
 
-  test('falls back to openai when only openai is configured', () => {
+  test('defaults to deepseek when provider is omitted', () => {
     delete process.env.AI_PROVIDER;
-    delete process.env.DEEPSEEK_API_KEY;
-    process.env.OPENAI_API_KEY = 'sk-test';
-    process.env.OPENAI_MODEL = 'gpt-4o-mini';
-
-    expect(_resolveAIProvider()).toBe('openai');
-
-    const settings = _getProviderSettings();
-    expect(settings.provider).toBe('openai');
-    expect(settings.model).toBe('gpt-4o-mini');
-    expect(settings.clientOptions.baseURL).toBeUndefined();
-  });
-
-  test('defaults to deepseek when no provider is configured', () => {
-    delete process.env.AI_PROVIDER;
-    delete process.env.DEEPSEEK_API_KEY;
-    delete process.env.OPENAI_API_KEY;
 
     expect(_resolveAIProvider()).toBe('deepseek');
   });
 
   test('throws for unsupported provider names', () => {
-    process.env.AI_PROVIDER = 'anthropic';
+    process.env.AI_PROVIDER = 'openai';
 
     expect(() => _resolveAIProvider()).toThrow('Unsupported AI provider');
   });


### PR DESCRIPTION
## Summary
- remove the silent OpenAI fallback from the AI provider layer
- make DeepSeek the only supported runtime provider for production chat and model-backed summaries
- update the privacy policy and docs so they match the intended deployed behavior

## Changes
- `server/services/ai/providerClient.js` now resolves only `deepseek`
- missing `DEEPSEEK_API_KEY` now fails closed instead of routing to another provider
- `.env.example` and `README.md` remove the fallback-provider instructions
- `client/src/pages/PrivacyPolicyPage.jsx` now states DeepSeek directly without temporary fallback wording
- `tests/providerClient.test.js` updated to cover DeepSeek-only behavior

## Validation
- `npm --prefix client run build`
- `NODE_ENV=test JWT_SECRET=test_jwt_secret_for_ci_pipeline_32ch JWT_REFRESH_SECRET=test_refresh_secret_for_ci_pipe ENCRYPTION_KEY=12345678901234567890123456789012 AI_PROVIDER=deepseek DEEPSEEK_API_KEY=ds-test npm test`
- backend tests passing: 117/117
- frontend production build passing

## Important
This PR is intentionally not merged yet because production cutover still requires the real `DEEPSEEK_API_KEY` to be set in Railway first. Merging before that risks breaking live chat.