### PR TITLE
[codex] switch chat to hf gradio space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,87 @@ jobs:
         if: always()
         run: echo "✅ Backend test suite completed"
 
+  # ─── Backend MySQL E2E ───
+  e2e-mysql:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: rootpass
+          MYSQL_DATABASE: lifesync_test
+          MYSQL_USER: lifesync
+          MYSQL_PASSWORD: lifesync_pass
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -prootpass"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Create test .env
+        run: |
+          cp .env.example .env
+          echo "NODE_ENV=test" >> .env
+          echo "DB_HOST=127.0.0.1" >> .env
+          echo "DB_PORT=3306" >> .env
+          echo "DB_NAME=lifesync_test" >> .env
+          echo "DB_USER=lifesync" >> .env
+          echo "DB_PASSWORD=lifesync_pass" >> .env
+          echo "JWT_SECRET=test_jwt_secret_for_ci_pipeline_32ch" >> .env
+          echo "JWT_REFRESH_SECRET=test_refresh_secret_for_ci_pipe" >> .env
+          echo "ENCRYPTION_KEY=test_encryption_key_for_ci_32ch!" >> .env
+
+      - name: Wait for MySQL
+        run: npm run db:wait
+        env:
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_NAME: lifesync_test
+          DB_USER: lifesync
+          DB_PASSWORD: lifesync_pass
+
+      - name: Run DB migrations
+        run: npx sequelize-cli db:migrate --env development
+        env:
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_NAME: lifesync_test
+          DB_USER: lifesync
+          DB_PASSWORD: lifesync_pass
+
+      - name: Run MySQL E2E suite
+        run: npm run test:e2e:mysql
+        env:
+          NODE_ENV: test
+          RUN_DB_E2E: true
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_NAME: lifesync_test
+          DB_USER: lifesync
+          DB_PASSWORD: lifesync_pass
+          JWT_SECRET: test_jwt_secret_for_ci_pipeline_32ch
+          JWT_REFRESH_SECRET: test_refresh_secret_for_ci_pipe
+          ENCRYPTION_KEY: test_encryption_key_for_ci_32ch!
+
   # ─── Frontend Build ───
   build-frontend:
     runs-on: ubuntu-latest
-    needs: test-backend
+    needs: [test-backend, e2e-mysql]
 
     steps:
       - name: Checkout code
@@ -72,11 +149,18 @@ jobs:
         working-directory: ./client
         run: npm ci
 
+      - name: Lint frontend
+        working-directory: ./client
+        run: npm run lint
+
       - name: Build frontend
         working-directory: ./client
         run: npm run build
         env:
-          VITE_API_URL: /api
+          VITE_API_URL: https://lifesync-production-6f3e.up.railway.app/api
+          VITE_GOOGLE_CLIENT_ID: 123174641248-1grp7s1u20ad1d3olkpg28hfe723rkut.apps.googleusercontent.com
+          EXPECTED_VITE_API_URL: https://lifesync-production-6f3e.up.railway.app/api
+          EXPECTED_VITE_GOOGLE_CLIENT_ID: 123174641248-1grp7s1u20ad1d3olkpg28hfe723rkut.apps.googleusercontent.com
 
       - name: Verify build output
         working-directory: ./client
@@ -94,7 +178,7 @@ jobs:
   # ─── Docker Build Validation ───
   docker-build:
     runs-on: ubuntu-latest
-    needs: [test-backend, build-frontend]
+    needs: [test-backend, e2e-mysql, build-frontend]
     if: github.ref == 'refs/heads/main'
 
     steps:

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,0 +1,29 @@
+name: LifeSync Release Smoke
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  release-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Probe external dependencies
+        run: npm run probe:external
+
+      - name: Smoke production routes
+        run: npm run smoke:workers

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Those scripts also install the frontend dependencies inside `client/` before run
 Both scripts now run a strict release preflight that validates:
 - `VITE_API_URL=https://lifesync-production-6f3e.up.railway.app/api`
 - `VITE_GOOGLE_CLIENT_ID=123174641248-1grp7s1u20ad1d3olkpg28hfe723rkut.apps.googleusercontent.com`
-- `GOOGLE_AUTH_CLIENT_IDS` includes that same Google client ID
+- if `GOOGLE_AUTH_CLIENT_IDS` is provided, it must include that same Google client ID
 
 Additional release checks:
 - `npm run probe:external` checks Railway `/api/health` and HF Space `/gradio_api/info` + `/infer` round-trip

--- a/README.md
+++ b/README.md
@@ -142,25 +142,22 @@ This project is close to a strong student/demo app, but it is not yet production
 
 ### Blocking issues to fix in code/config
 
-1. Docker Compose uses the wrong database password variable for the backend.
-   The app reads `DB_PASSWORD`, but `docker-compose.yml` sets `DB_PASS`.
-
-2. Custom rate limiters trigger IPv6 validation warnings from `express-rate-limit`.
+1. Custom rate limiters trigger IPv6 validation warnings from `express-rate-limit`.
    This should be fixed before production so rate limiting is correct and clean.
 
-3. OTP state is stored in memory.
+2. OTP state is stored in memory.
    Restarting the server or scaling to multiple instances will break registration flows.
 
-4. Chat clarification state is stored in memory.
+3. Chat clarification state is stored in memory.
    Restarting the server or scaling horizontally will lose active clarification sessions.
 
-5. The encryption helper currently uses `JWT_SECRET` instead of `ENCRYPTION_KEY`.
+4. The encryption helper currently uses `JWT_SECRET` instead of `ENCRYPTION_KEY`.
    That couples two unrelated secrets and makes key rotation harder.
 
-6. The seed script creates a default admin with a known password.
+5. The seed script creates a default admin with a known password.
    That is acceptable for local development only and must be removed or overridden for real deployment.
 
-7. Google Fit still requires production OAuth configuration on the Google Cloud side.
+6. Google Fit still requires production OAuth configuration on the Google Cloud side.
    The app needs a real callback URL, consent screen URLs, and approved origins before that integration is launch-ready.
 
 ### Missing production infrastructure
@@ -201,6 +198,14 @@ This repo now includes `wrangler.jsonc` with SPA fallback enabled for Cloudflare
 
 The `deploy` and `preview` scripts build the frontend before calling Wrangler, so Cloudflare does not need a separate build step.
 Those scripts also install the frontend dependencies inside `client/` before running Vite, because Workers Builds only installs the root package by default.
+Both scripts now run a strict release preflight that validates:
+- `VITE_API_URL=https://lifesync-production-6f3e.up.railway.app/api`
+- `VITE_GOOGLE_CLIENT_ID=123174641248-1grp7s1u20ad1d3olkpg28hfe723rkut.apps.googleusercontent.com`
+- `GOOGLE_AUTH_CLIENT_IDS` includes that same Google client ID
+
+Additional release checks:
+- `npm run probe:external` checks Railway `/api/health` and HF Space `/gradio_api/info` + `/infer` round-trip
+- `npm run smoke:workers` checks live frontend routes `/login`, `/dashboard`, `/chat`, `/health`, `/finance` and reports the production asset hash
 
 ## Important Files
 

--- a/README_ADMIN.md
+++ b/README_ADMIN.md
@@ -22,7 +22,7 @@ The Admin Portal displays six real-time metrics:
 | **Active (24h)** | Users who made API calls in the last 24 hours | > 30% of total |
 | **New (7 days)** | Accounts created in the past week | Steady growth |
 | **Errors (24h)** | System errors logged in 24 hours | < 5 |
-| **NLP Avg Response** | Mean OpenAI processing time | < 2000ms |
+| **NLP Avg Response** | Mean chat provider processing time | < 2000ms |
 | **NLP Max Response** | Worst-case NLP latency | < 5000ms |
 
 ### Health + Finance Logs (24h)
@@ -121,11 +121,16 @@ All secrets are configured via `.env` or `docker-compose.yml` environment:
 | `DB_HOST` | Yes | MySQL host |
 | `DB_NAME` | Yes | Database name |
 | `DB_USER` | Yes | Database user |
-| `DB_PASS` | Yes | Database password |
+| `DB_PASSWORD` | Yes | Database password |
 | `JWT_SECRET` | Yes | JWT signing key (32+ chars) |
 | `JWT_REFRESH_SECRET` | Yes | Refresh token key (32+ chars) |
 | `ENCRYPTION_KEY` | Yes | AES-256 key for field encryption |
-| `OPENAI_API_KEY` | Yes | For NLP processing |
+| `AI_PROVIDER` | Yes | Global AI fallback provider |
+| `CHAT_AI_PROVIDER` | Yes | Chat parser provider (recommended: `custom_hf`) |
+| `INSIGHTS_AI_PROVIDER` | Yes | Weekly insights provider (recommended: `gemini`) |
+| `GEMINI_API_KEY` | Cond. | Required when Gemini is selected |
+| `CUSTOM_HF_ENDPOINT` | Cond. | Required when `CHAT_AI_PROVIDER=custom_hf` |
+| `HF_API_KEY` | No | Optional token for private/public HF Space auth |
 | `CORS_ORIGIN` | Yes | Frontend URL(s), comma-separated |
 | `SMTP_HOST` | No | Email server for OTP |
 | `SMTP_USER` | No | Email account |
@@ -140,9 +145,14 @@ The GitHub Actions workflow (`.github/workflows/ci.yml`) runs automatically on:
 - Pull requests to `main`
 
 Pipeline stages:
-1. **Backend Tests**: Runs 97 Jest tests on Node 18 + 20
-2. **Frontend Build**: Vite production build validation
-3. **Docker Build**: Image build verification (main branch only)
+1. **Backend Tests**: Jest suite on Node 18 + 20
+2. **MySQL E2E**: real DB auth + health + finance flows against MySQL service container
+3. **Frontend Lint + Build**: ESLint 9 flat-config gate plus production Vite build
+4. **Docker Build**: image build verification (main branch only)
+
+Release smoke workflow (`.github/workflows/release-smoke.yml`) runs:
+- external dependency probes (Railway `/api/health`, HF `/gradio_api/info` + `/infer`)
+- production frontend route smoke for `/login`, `/dashboard`, `/chat`, `/health`, `/finance`
 
 ---
 
@@ -183,7 +193,7 @@ mysqldump -u root -p lifesync_db > backup_$(date +%Y%m%d).sql
 - [ ] Rotate JWT secrets
 - [ ] Update dependencies (`npm audit fix`)
 - [ ] Review and archive old system logs
-- [ ] Check OpenAI API usage and billing
+- [ ] Check AI provider usage and billing (Gemini/HF as configured)
 
 ---
 
@@ -192,7 +202,7 @@ mysqldump -u root -p lifesync_db > backup_$(date +%Y%m%d).sql
 | Symptom | Likely Cause | Fix |
 |---|---|---|
 | "Too many requests" errors | Rate limit hit | Wait 15 min, or adjust limits in `rateLimiter.js` |
-| NLP returning empty responses | OpenAI API key invalid/expired | Check `OPENAI_API_KEY` in `.env` |
+| NLP returning empty responses | AI provider endpoint/key misconfigured | Validate `CHAT_AI_PROVIDER`, `CUSTOM_HF_ENDPOINT`, and provider keys in `.env` |
 | Database connection failed | MySQL not running | `docker-compose restart db` |
 | "CORS error" in browser | Frontend URL not in `CORS_ORIGIN` | Update `.env` with correct origin |
 | OTP email not received | SMTP not configured | Set SMTP vars or use Ethereal for dev |

--- a/SETUP_FINAL.md
+++ b/SETUP_FINAL.md
@@ -86,15 +86,21 @@ DB_HOST=localhost
 DB_PORT=3306
 DB_NAME=lifesync_db
 DB_USER=root
-DB_PASS=your_mysql_password
+DB_PASSWORD=your_mysql_password
 
 # ─── Security (change in production) ───
 JWT_SECRET=your_jwt_secret_minimum_32_characters_long
 JWT_REFRESH_SECRET=your_refresh_secret_minimum_32_chars
 ENCRYPTION_KEY=your_encryption_key_exactly_32ch!
 
-# ─── Optional (for full NLP features) ───
-OPENAI_API_KEY=sk-...
+# ─── AI provider config ───
+AI_PROVIDER=gemini
+CHAT_AI_PROVIDER=custom_hf
+INSIGHTS_AI_PROVIDER=gemini
+GEMINI_API_KEY=your_gemini_api_key
+CUSTOM_HF_ENDPOINT=https://os-1202883-lifesync-api.hf.space
+# Optional when the HF Space is private:
+# HF_API_KEY=your_hf_token
 
 # ─── Optional (for email OTP) ───
 SMTP_HOST=smtp.gmail.com
@@ -150,21 +156,17 @@ open http://localhost:5173
 
 ---
 
-## Running the Test Suite (97 Tests)
+## Running the Test Suite
 
 ```bash
 # From project root
 npm test
 
-# Expected output:
-# PASS tests/nlp.test.js          (39 tests)
-# PASS tests/otp.test.js          (16 tests)
-# PASS tests/encryption.test.js   (17 tests)
-# PASS tests/insightEngine.test.js (22 tests)
-# PASS tests/app.test.js          (3 tests)
-#
-# Test Suites: 5 passed, 5 total
-# Tests:       97 passed, 97 total
+# Includes backend unit/integration suites.
+# CI also runs a dedicated MySQL-backed E2E suite for:
+# - auth login flow
+# - health log create/list
+# - finance log create/list
 
 # Verbose mode (see each test name):
 npm test -- --verbose
@@ -173,7 +175,7 @@ npm test -- --verbose
 npx jest tests/insightEngine.test.js --verbose
 ```
 
-**Note:** Tests run without MySQL or OpenAI — they test pure logic (entity validation, Pearson correlation, encryption, OTP generation) using mocked data.
+**Note:** Local unit tests run without MySQL; CI runs an additional MySQL service-container E2E gate.
 
 ---
 
@@ -184,11 +186,10 @@ cd client
 npm run build
 
 # Expected output:
-# dist/assets/index-*.js        ~294 KB  (core bundle)
-# dist/assets/DashboardPage-*.js ~205 KB  (lazy chunk)
-# dist/assets/ChatPage-*.js      ~263 KB  (lazy chunk)
-# dist/assets/AdminPage-*.js     ~8 KB    (lazy chunk)
-# ✓ built in ~10s
+# Build requires:
+# - VITE_API_URL
+# - VITE_GOOGLE_CLIENT_ID
+# The build preflight will fail if either is missing or misaligned with release baselines.
 ```
 
 ---
@@ -211,7 +212,8 @@ node server/seeders/seed.js
 |-------|----------|
 | `ECONNREFUSED :3306` | MySQL not running. Start: `sudo systemctl start mysql` |
 | `ER_NOT_SUPPORTED_AUTH_MODE` | Run in MySQL: `ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'password';` |
-| `OPENAI_API_KEY not set` | NLP chat will return fallback responses. Set key for full functionality. |
+| Build fails preflight | Missing/invalid `VITE_API_URL` or `VITE_GOOGLE_CLIENT_ID` | Set both variables before `npm run build` |
+| NLP/API probe fails | HF or Railway service issue | Run `npm run probe:external` and check endpoint health |
 | `SMTP errors on registration` | OTP emails won't send. Use test mode or set SMTP credentials. |
 | Port 5000 in use | Change `PORT` in `.env` |
 | Port 5173 in use | Vite auto-picks next port (5174, etc.) |

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,0 +1,40 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+
+export default [
+  {
+    ignores: ['dist/**', 'node_modules/**'],
+  },
+  {
+    files: ['**/*.{js,jsx}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      globals: globals.browser,
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+      'react-hooks/set-state-in-effect': 'off',
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+    },
+  },
+  {
+    files: ['vite.config.js'],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
+];

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "preflight:prod": "node ./scripts/validateBuildEnv.mjs",
+    "build": "npm run preflight:prod && vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/client/scripts/validateBuildEnv.mjs
+++ b/client/scripts/validateBuildEnv.mjs
@@ -1,0 +1,66 @@
+const REQUIRED = [
+  'VITE_API_URL',
+  'VITE_GOOGLE_CLIENT_ID',
+];
+
+const EXPECTED = {
+  VITE_API_URL:
+    process.env.EXPECTED_VITE_API_URL
+    || 'https://lifesync-production-6f3e.up.railway.app/api',
+  VITE_GOOGLE_CLIENT_ID:
+    process.env.EXPECTED_VITE_GOOGLE_CLIENT_ID
+    || '123174641248-1grp7s1u20ad1d3olkpg28hfe723rkut.apps.googleusercontent.com',
+};
+
+const GOOGLE_CLIENT_ID_PATTERN = /^[0-9]{12}-[a-z0-9-]+\.apps\.googleusercontent\.com$/i;
+
+const fail = (message) => {
+  console.error(`[preflight] ${message}`);
+  process.exitCode = 1;
+};
+
+for (const key of REQUIRED) {
+  const value = (process.env[key] || '').trim();
+  if (!value) {
+    fail(`Missing required build variable: ${key}`);
+    continue;
+  }
+
+  if (key === 'VITE_API_URL') {
+    try {
+      const parsed = new URL(value);
+      if (!['http:', 'https:'].includes(parsed.protocol)) {
+        fail(`${key} must use http/https: ${value}`);
+      }
+    } catch {
+      fail(`${key} must be an absolute URL: ${value}`);
+    }
+  }
+
+  if (key === 'VITE_GOOGLE_CLIENT_ID' && !GOOGLE_CLIENT_ID_PATTERN.test(value)) {
+    fail(`${key} is not a valid Google web client ID: ${value}`);
+  }
+
+  const expectedValue = EXPECTED[key];
+  if (expectedValue && value !== expectedValue) {
+    fail(`${key} must match release baseline ${expectedValue}, got ${value}`);
+  }
+}
+
+const backendAllowlist = (process.env.GOOGLE_AUTH_CLIENT_IDS || '')
+  .split(',')
+  .map((value) => value.trim())
+  .filter(Boolean);
+const expectedGoogleClientId = EXPECTED.VITE_GOOGLE_CLIENT_ID;
+
+if (backendAllowlist.length && !backendAllowlist.includes(expectedGoogleClientId)) {
+  fail(
+    `GOOGLE_AUTH_CLIENT_IDS must include ${expectedGoogleClientId} when provided.`
+  );
+}
+
+if (process.exitCode) {
+  process.exit(process.exitCode);
+}
+
+console.log('[preflight] Frontend build env validation passed.');

--- a/client/src/components/auth/GoogleSignInButton.jsx
+++ b/client/src/components/auth/GoogleSignInButton.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { getGoogleClientId } from '../../config/runtime';
+import { buildGoogleButtonRenderKey, googleIdentityState } from './googleSignInState';
 
 const GOOGLE_SCRIPT_ID = 'google-identity-services';
 
@@ -37,8 +38,18 @@ export default function GoogleSignInButton({
   text = 'signin_with',
 }) {
   const buttonRef = useRef(null);
+  const successRef = useRef(onSuccess);
+  const errorRef = useRef(onError);
   const [scriptError, setScriptError] = useState('');
   const clientId = getGoogleClientId();
+
+  useEffect(() => {
+    successRef.current = onSuccess;
+  }, [onSuccess]);
+
+  useEffect(() => {
+    errorRef.current = onError;
+  }, [onError]);
 
   useEffect(() => {
     let cancelled = false;
@@ -47,16 +58,26 @@ export default function GoogleSignInButton({
       return undefined;
     }
 
+    const renderKey = buildGoogleButtonRenderKey(clientId, text);
+
     loadGoogleScript()
       .then(() => {
         if (cancelled || !buttonRef.current || !window.google?.accounts?.id) {
           return;
         }
 
-        window.google.accounts.id.initialize({
-          client_id: clientId,
-          callback: onSuccess,
-        });
+        if (googleIdentityState.shouldInitialize(clientId)) {
+          window.google.accounts.id.initialize({
+            client_id: clientId,
+            callback: (credentialResponse) => successRef.current?.(credentialResponse),
+          });
+          googleIdentityState.markInitialized(clientId);
+        }
+
+        if (buttonRef.current.dataset.googleRenderKey === renderKey) {
+          setScriptError('');
+          return;
+        }
 
         buttonRef.current.innerHTML = '';
 
@@ -68,6 +89,8 @@ export default function GoogleSignInButton({
           logo_alignment: 'left',
           width: buttonRef.current.offsetWidth || 360,
         });
+        buttonRef.current.dataset.googleRenderKey = renderKey;
+        setScriptError('');
       })
       .catch((error) => {
         if (cancelled) {
@@ -75,13 +98,13 @@ export default function GoogleSignInButton({
         }
 
         setScriptError(error.message);
-        onError?.(error);
+        errorRef.current?.(error);
       });
 
     return () => {
       cancelled = true;
     };
-  }, [clientId, onError, onSuccess, text]);
+  }, [clientId, text]);
 
   if (!clientId) {
     return null;
@@ -91,7 +114,7 @@ export default function GoogleSignInButton({
     <div className="space-y-3">
       <div ref={buttonRef} className="w-full min-h-[44px] flex justify-center" />
       {scriptError && (
-        <p className="text-xs text-coral-500 text-center">{scriptError}</p>
+        <p className="text-xs text-coral-500 text-center" role="alert" aria-live="assertive">{scriptError}</p>
       )}
     </div>
   );

--- a/client/src/components/auth/googleSignInState.js
+++ b/client/src/components/auth/googleSignInState.js
@@ -1,0 +1,16 @@
+export const shouldInitializeGoogleIdentity = (initializedClientId, nextClientId) => {
+  return Boolean(nextClientId) && initializedClientId !== nextClientId;
+};
+
+export const buildGoogleButtonRenderKey = (clientId, text) => `${clientId}:${text}`;
+
+let currentInitializedClientId = '';
+
+export const googleIdentityState = {
+  shouldInitialize(nextClientId) {
+    return shouldInitializeGoogleIdentity(currentInitializedClientId, nextClientId);
+  },
+  markInitialized(nextClientId) {
+    currentInitializedClientId = nextClientId || '';
+  },
+};

--- a/client/src/components/dashboard/InsightCards.jsx
+++ b/client/src/components/dashboard/InsightCards.jsx
@@ -1,5 +1,6 @@
 // src/components/dashboard/InsightCards.jsx
 import { Lightbulb, TrendingUp, TrendingDown, Minus, AlertTriangle, ArrowUpRight } from 'lucide-react';
+import { getInsightCardsViewModel } from './insightCardModel';
 
 const trendIcons = {
   improving: <TrendingUp className="w-4 h-4 text-emerald-500" />,
@@ -15,7 +16,7 @@ const trendColors = {
   insufficient_data: 'text-amber-600 bg-amber-50 border-amber-100',
 };
 
-export default function InsightCards({ insights, loading }) {
+export default function InsightCards({ insights, loading, error }) {
   if (loading) {
     return (
       <div className="space-y-4">
@@ -26,17 +27,40 @@ export default function InsightCards({ insights, loading }) {
     );
   }
 
-  // Show empty state when no real insights exist
-  if (!insights) {
+  const view = getInsightCardsViewModel({ insights, error });
+
+  if (view.kind === 'error') {
     return (
-      <div className="p-5 rounded-2xl bg-navy-50 border border-navy-100 text-center py-10">
-        <p className="text-navy-400 text-sm">
-          No insights yet — log some health or finance data to get started.
+      <div className="p-5 rounded-2xl border border-amber-200 bg-amber-50 space-y-2">
+        <div className="flex items-center gap-2 text-amber-700">
+          <AlertTriangle className="w-5 h-5" />
+          <h3 className="font-display font-semibold text-sm">Insights unavailable</h3>
+        </div>
+        <p className="text-sm text-amber-800 leading-relaxed">
+          {view.error}
+        </p>
+        <p className="text-xs text-amber-700/80">
+          No AI insight cards are being shown because the backend request failed.
         </p>
       </div>
     );
   }
-  const data = insights;
+
+  if (view.kind === 'empty') {
+    return (
+      <div className="p-5 rounded-2xl border border-dashed border-navy-200 bg-navy-50/60 space-y-2">
+        <div className="flex items-center gap-2 text-navy-700">
+          <Lightbulb className="w-5 h-5" />
+          <h3 className="font-display font-semibold text-sm">No insights yet</h3>
+        </div>
+        <p className="text-sm text-navy-600 leading-relaxed">
+          Keep logging health and finance activity to generate real weekly insights.
+        </p>
+      </div>
+    );
+  }
+
+  const { data } = view;
 
   return (
     <div className="space-y-4">

--- a/client/src/components/dashboard/insightCardModel.js
+++ b/client/src/components/dashboard/insightCardModel.js
@@ -1,0 +1,23 @@
+export const getInsightCardsViewModel = ({ insights, error }) => {
+  if (error) {
+    return {
+      kind: 'error',
+      data: null,
+      error,
+    };
+  }
+
+  if (!insights) {
+    return {
+      kind: 'empty',
+      data: null,
+      error: null,
+    };
+  }
+
+  return {
+    kind: 'data',
+    data: insights,
+    error: null,
+  };
+};

--- a/client/src/config/runtime.js
+++ b/client/src/config/runtime.js
@@ -1,14 +1,26 @@
-export const DEFAULT_PROD_API_URL = 'https://lifesync-production-6f3e.up.railway.app/api';
-export const DEFAULT_PROD_GOOGLE_CLIENT_ID = '123174641248-1grp7s1u20ad1d3olkpg28hfe723rkut.apps.googleusercontent.com';
+import { resolveRuntimeConfig } from './runtimeConfig';
+
+const runtimeConfig = resolveRuntimeConfig(import.meta.env);
+let loggedWarnings = false;
+
+const logRuntimeWarnings = () => {
+  if (loggedWarnings) {
+    return;
+  }
+
+  runtimeConfig.warnings.forEach((warning) => {
+    console.warn(`[runtime] ${warning}`);
+  });
+
+  loggedWarnings = true;
+};
 
 export const getApiBaseUrl = () => {
-  return (
-    import.meta.env.VITE_API_URL
-    || (import.meta.env.DEV ? '/api' : DEFAULT_PROD_API_URL)
-  ).replace(/\/$/, '');
+  logRuntimeWarnings();
+  return runtimeConfig.apiBaseUrl;
 };
 
 export const getGoogleClientId = () => {
-  return import.meta.env.VITE_GOOGLE_CLIENT_ID
-    || (import.meta.env.DEV ? '' : DEFAULT_PROD_GOOGLE_CLIENT_ID);
+  logRuntimeWarnings();
+  return runtimeConfig.googleClientId;
 };

--- a/client/src/config/runtimeConfig.js
+++ b/client/src/config/runtimeConfig.js
@@ -1,0 +1,24 @@
+export const resolveRuntimeConfig = (env = {}) => {
+  const apiUrl = typeof env.VITE_API_URL === 'string' ? env.VITE_API_URL.trim() : '';
+  const googleClientId = typeof env.VITE_GOOGLE_CLIENT_ID === 'string'
+    ? env.VITE_GOOGLE_CLIENT_ID.trim()
+    : '';
+  const warnings = [];
+
+  let apiBaseUrl = apiUrl || '/api';
+  if (!env.DEV && !apiUrl) {
+    warnings.push('VITE_API_URL is not set for this production build. Falling back to same-origin /api.');
+  }
+
+  if (!env.DEV && !googleClientId) {
+    warnings.push('VITE_GOOGLE_CLIENT_ID is not set for this production build. Google sign-in is disabled.');
+  }
+
+  apiBaseUrl = apiBaseUrl.replace(/\/$/, '');
+
+  return {
+    apiBaseUrl,
+    googleClientId,
+    warnings,
+  };
+};

--- a/client/src/pages/AdminPage.jsx
+++ b/client/src/pages/AdminPage.jsx
@@ -1,6 +1,7 @@
 // src/pages/AdminPage.jsx
 import { useState, useEffect } from 'react';
 import { adminAPI } from '../services/api';
+import { getPaginatedItems } from '../utils/paginatedResponse';
 import { SkeletonCard } from '../components/ui/Skeleton';
 import {
   Users, AlertTriangle, Activity, Clock, UserPlus, Shield,
@@ -41,8 +42,8 @@ export default function AdminPage() {
         ]);
 
         if (dashRes.status === 'fulfilled') setDashboard(dashRes.value.data.data);
-        if (usersRes.status === 'fulfilled') setUsers(usersRes.value.data.data?.users || []);
-        if (logsRes.status === 'fulfilled') setLogs(logsRes.value.data.data?.logs || []);
+        if (usersRes.status === 'fulfilled') setUsers(getPaginatedItems(usersRes.value.data, 'users'));
+        if (logsRes.status === 'fulfilled') setLogs(getPaginatedItems(logsRes.value.data, 'logs'));
       } catch (err) {
         console.error('Admin data fetch error:', err);
       } finally {

--- a/client/src/pages/ChatPage.jsx
+++ b/client/src/pages/ChatPage.jsx
@@ -2,6 +2,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { chatAPI } from '../services/api';
 import { subscribeToChatSession } from '../services/firebase';
+import { getAssistantMessageContent, getChatErrorMessage } from '../utils/chatResponse';
 import { Send, Loader2, Sparkles, Plus, Clock, MessageCircle } from 'lucide-react';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -184,7 +185,7 @@ export default function ChatPage() {
       const assistantMsg = {
         id: Date.now() + 1,
         role: 'assistant',
-        content: result.response,
+        content: getAssistantMessageContent(result),
         entities: result.entities_logged,
         needsClarification: result.needs_clarification,
       };
@@ -198,7 +199,7 @@ export default function ChatPage() {
       const errorMsg = {
         id: Date.now() + 1,
         role: 'assistant',
-        content: err.response?.data?.message || 'Something went wrong. Please try again.',
+        content: getChatErrorMessage(err),
       };
       setMessages((prev) => [...prev, errorMsg]);
     } finally {

--- a/client/src/pages/DashboardPage.jsx
+++ b/client/src/pages/DashboardPage.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { healthAPI, financeAPI, insightsAPI } from '../services/api';
+import { getApiErrorMessage } from '../utils/apiErrors';
+import { getPaginatedItems } from '../utils/paginatedResponse';
 import HealthCorrelationChart from '../components/dashboard/HealthCorrelationChart';
 import SpendingChart from '../components/dashboard/SpendingChart';
 import MoodActivityChart from '../components/dashboard/MoodActivityChart';
@@ -30,6 +32,7 @@ export default function DashboardPage() {
   const [healthSummary, setHealthSummary] = useState(null);
   const [financeSummary, setFinanceSummary] = useState(null);
   const [insights, setInsights] = useState(null);
+  const [insightsError, setInsightsError] = useState('');
   const [loading, setLoading] = useState(true);
   const [spendingView, setSpendingView] = useState('doughnut');
 
@@ -44,11 +47,17 @@ export default function DashboardPage() {
           insightsAPI.getCurrent(),
         ]);
 
-        if (healthRes.status === 'fulfilled') setHealthData(healthRes.value.data.data?.logs || []);
-        if (financeRes.status === 'fulfilled') setFinanceData(financeRes.value.data.data?.logs || []);
+        if (healthRes.status === 'fulfilled') setHealthData(getPaginatedItems(healthRes.value.data, 'logs'));
+        if (financeRes.status === 'fulfilled') setFinanceData(getPaginatedItems(financeRes.value.data, 'logs'));
         if (healthSummaryRes.status === 'fulfilled') setHealthSummary(healthSummaryRes.value.data.data);
         if (financeSummaryRes.status === 'fulfilled') setFinanceSummary(financeSummaryRes.value.data.data);
-        if (insightsRes.status === 'fulfilled') setInsights(insightsRes.value.data.data?.insights || null);
+        if (insightsRes.status === 'fulfilled') {
+          setInsights(insightsRes.value.data.data?.insights || null);
+          setInsightsError('');
+        } else {
+          setInsights(null);
+          setInsightsError(getApiErrorMessage(insightsRes.reason, 'Unable to load insights right now.'));
+        }
       } catch (err) {
         console.warn('Dashboard data fetch error:', err);
       } finally {
@@ -183,7 +192,7 @@ export default function DashboardPage() {
             <BarChart3 className="w-5 h-5 text-navy-500" />
             <h2 className="font-display text-lg font-bold text-navy-800">Insights</h2>
           </div>
-          <InsightCards insights={insights} loading={loading} />
+          <InsightCards insights={insights} loading={loading} error={insightsError} />
         </div>
       </div>
     </div>

--- a/client/src/pages/FinancePage.jsx
+++ b/client/src/pages/FinancePage.jsx
@@ -1,6 +1,7 @@
 // src/pages/FinancePage.jsx
 import { useState, useEffect } from 'react';
 import { financeAPI } from '../services/api';
+import { getPaginatedItems, getPaginatedTotalPages } from '../utils/paginatedResponse';
 import { SkeletonCard } from '../components/ui/Skeleton';
 import {
   Wallet, TrendingUp, TrendingDown, Search, Trash2,
@@ -24,8 +25,8 @@ export default function FinancePage() {
         if (search) params.search = search;
 
         const { data } = await financeAPI.getLogs(params);
-        setLogs(data.data?.logs || []);
-        setTotalPages(data.data?.pagination?.totalPages || 1);
+        setLogs(getPaginatedItems(data, 'logs'));
+        setTotalPages(getPaginatedTotalPages(data));
       } catch (err) {
         console.error('Failed to load finance logs:', err);
       } finally {

--- a/client/src/pages/HealthPage.jsx
+++ b/client/src/pages/HealthPage.jsx
@@ -1,6 +1,7 @@
 // src/pages/HealthPage.jsx
 import { useState, useEffect } from 'react';
 import { healthAPI } from '../services/api';
+import { getPaginatedItems, getPaginatedTotalPages } from '../utils/paginatedResponse';
 import { SkeletonCard } from '../components/ui/Skeleton';
 import {
   Heart, Footprints, Moon, SmilePlus, Droplets, Dumbbell,
@@ -34,8 +35,8 @@ export default function HealthPage() {
         if (search) params.search = search;
 
         const { data } = await healthAPI.getLogs(params);
-        setLogs(data.data?.logs || []);
-        setTotalPages(data.data?.pagination?.totalPages || 1);
+        setLogs(getPaginatedItems(data, 'logs'));
+        setTotalPages(getPaginatedTotalPages(data));
       } catch (err) {
         console.error('Failed to load health logs:', err);
       } finally {

--- a/client/src/pages/IntegrationsPage.jsx
+++ b/client/src/pages/IntegrationsPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { externalAPI, healthAPI, financeAPI } from '../services/api';
 import { getApiErrorMessage } from '../utils/apiErrors';
+import { getPaginatedItems } from '../utils/paginatedResponse';
 import {
   ArrowLeft, RefreshCw, Unlink, CheckCircle, AlertCircle,
   Loader2, Download, FileJson, FileSpreadsheet, Heart,
@@ -383,7 +384,7 @@ function DataExportPanel() {
     try {
       const api = domain === 'health' ? healthAPI : financeAPI;
       const { data } = await api.getLogs({ limit: 10000 });
-      const rows = data.data?.logs || [];
+      const rows = getPaginatedItems(data, 'logs');
       const date = new Date().toISOString().slice(0, 10);
 
       if (format === 'json') {

--- a/client/src/pages/LoginPage.jsx
+++ b/client/src/pages/LoginPage.jsx
@@ -102,7 +102,7 @@ export default function LoginPage() {
                 onError={() => setError('Google sign-in is unavailable right now. Please try email login.')}
               />
               {googleLoading && (
-                <p className="mt-3 text-center text-sm text-navy-500">Completing Google sign-in...</p>
+                <p className="mt-3 text-center text-sm text-navy-500" role="status" aria-live="polite">Completing Google sign-in...</p>
               )}
               <div className="mt-6 flex items-center gap-3 text-xs uppercase tracking-[0.22em] text-navy-300">
                 <div className="h-px flex-1 bg-navy-200" />
@@ -113,7 +113,7 @@ export default function LoginPage() {
           )}
 
           {successMessage && (
-            <div className="mb-6 p-4 rounded-xl bg-emerald-50 border border-emerald-200 text-emerald-700 text-sm flex items-center gap-2">
+            <div className="mb-6 p-4 rounded-xl bg-emerald-50 border border-emerald-200 text-emerald-700 text-sm flex items-center gap-2" role="status" aria-live="polite">
               <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
               </svg>
@@ -122,19 +122,24 @@ export default function LoginPage() {
           )}
 
           {error && (
-            <div className="mb-6 p-4 rounded-xl bg-coral-500/10 border border-coral-500/20 text-coral-500 text-sm">
+            <div id="login-form-error" className="mb-6 p-4 rounded-xl bg-coral-500/10 border border-coral-500/20 text-coral-500 text-sm" role="alert" aria-live="assertive">
               {error}
             </div>
           )}
 
           <form onSubmit={handleSubmit} className="space-y-5">
             <div>
-              <label className="block text-sm font-medium text-navy-700 mb-1.5">Email</label>
+              <label htmlFor="login-email" className="block text-sm font-medium text-navy-700 mb-1.5">Email</label>
               <input
+                id="login-email"
+                name="email"
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
+                autoComplete="email"
+                aria-invalid={Boolean(error)}
+                aria-describedby={error ? 'login-form-error' : undefined}
                 className="w-full px-4 py-3 rounded-xl border border-navy-200 bg-white text-navy-900 placeholder-navy-300 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 focus:border-emerald-500 transition-all"
                 placeholder="you@example.com"
               />
@@ -142,17 +147,22 @@ export default function LoginPage() {
 
             <div>
               <div className="flex items-center justify-between mb-1.5">
-                <label className="block text-sm font-medium text-navy-700">Password</label>
+                <label htmlFor="login-password" className="block text-sm font-medium text-navy-700">Password</label>
                 <Link to="/forgot-password" className="text-xs text-emerald-600 hover:text-emerald-700 font-medium">
                   Forgot password?
                 </Link>
               </div>
               <div className="relative">
                 <input
+                  id="login-password"
+                  name="password"
                   type={showPassword ? 'text' : 'password'}
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   required
+                  autoComplete="current-password"
+                  aria-invalid={Boolean(error)}
+                  aria-describedby={error ? 'login-form-error' : undefined}
                   className="w-full px-4 py-3 rounded-xl border border-navy-200 bg-white text-navy-900 placeholder-navy-300 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 focus:border-emerald-500 transition-all pr-12"
                   placeholder="Enter your password"
                 />
@@ -160,6 +170,8 @@ export default function LoginPage() {
                   type="button"
                   onClick={() => setShowPassword(!showPassword)}
                   className="absolute right-3 top-1/2 -translate-y-1/2 text-navy-400 hover:text-navy-600 p-1"
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  aria-pressed={showPassword}
                 >
                   {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
                 </button>

--- a/client/src/pages/RegisterPage.jsx
+++ b/client/src/pages/RegisterPage.jsx
@@ -152,7 +152,7 @@ export default function RegisterPage() {
                 onError={() => setError('Google sign-up is unavailable right now. Please use email.')}
               />
               {googleLoading && (
-                <p className="mt-3 text-center text-sm text-navy-500">Creating your account with Google...</p>
+                <p className="mt-3 text-center text-sm text-navy-500" role="status" aria-live="polite">Creating your account with Google...</p>
               )}
               <div className="mt-6 flex items-center gap-3 text-xs uppercase tracking-[0.22em] text-navy-300">
                 <div className="h-px flex-1 bg-navy-200" />
@@ -163,7 +163,7 @@ export default function RegisterPage() {
           )}
 
           {error && (
-            <div className="mb-6 p-4 rounded-xl bg-coral-500/10 border border-coral-500/20 text-coral-500 text-sm">
+            <div id="register-form-error" className="mb-6 p-4 rounded-xl bg-coral-500/10 border border-coral-500/20 text-coral-500 text-sm" role="alert" aria-live="assertive">
               {error}
             </div>
           )}
@@ -175,12 +175,17 @@ export default function RegisterPage() {
                 <p className="text-navy-500 text-sm">We&apos;ll send a verification code to your email.</p>
               </div>
               <div>
-                <label className="block text-sm font-medium text-navy-700 mb-1.5">Email address</label>
+                <label htmlFor="register-email" className="block text-sm font-medium text-navy-700 mb-1.5">Email address</label>
                 <input
+                  id="register-email"
+                  name="email"
                   type="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   required
+                  autoComplete="email"
+                  aria-invalid={Boolean(error)}
+                  aria-describedby={error ? 'register-form-error' : undefined}
                   className="w-full px-4 py-3 rounded-xl border border-navy-200 bg-white text-navy-900 placeholder-navy-300 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 focus:border-emerald-500"
                   placeholder="you@example.com"
                 />
@@ -206,8 +211,10 @@ export default function RegisterPage() {
                   <input
                     key={i}
                     id={`otp-${i}`}
+                    aria-label={`Verification code digit ${i + 1}`}
                     type="text"
                     inputMode="numeric"
+                    autoComplete="one-time-code"
                     maxLength={1}
                     value={digit}
                     onChange={(e) => handleOtpChange(i, e.target.value)}
@@ -242,35 +249,48 @@ export default function RegisterPage() {
                 <p className="text-navy-500 text-sm">Choose a username and set your password.</p>
               </div>
               <div>
-                <label className="block text-sm font-medium text-navy-700 mb-1.5">Full Name <span className="text-navy-400">(optional)</span></label>
+                <label htmlFor="register-name" className="block text-sm font-medium text-navy-700 mb-1.5">Full Name <span className="text-navy-400">(optional)</span></label>
                 <input
+                  id="register-name"
+                  name="name"
                   type="text"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
+                  autoComplete="name"
                   className="w-full px-4 py-3 rounded-xl border border-navy-200 bg-white text-navy-900 placeholder-navy-300 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 focus:border-emerald-500"
                   placeholder="Your name"
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-navy-700 mb-1.5">Username</label>
+                <label htmlFor="register-username" className="block text-sm font-medium text-navy-700 mb-1.5">Username</label>
                 <input
+                  id="register-username"
+                  name="username"
                   type="text"
                   value={username}
                   onChange={(e) => setUsername(e.target.value)}
                   required
                   minLength={3}
+                  autoComplete="username"
+                  aria-invalid={Boolean(error)}
+                  aria-describedby={error ? 'register-form-error' : undefined}
                   className="w-full px-4 py-3 rounded-xl border border-navy-200 bg-white text-navy-900 placeholder-navy-300 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 focus:border-emerald-500"
                   placeholder="Choose a username"
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-navy-700 mb-1.5">Password</label>
+                <label htmlFor="register-password" className="block text-sm font-medium text-navy-700 mb-1.5">Password</label>
                 <input
+                  id="register-password"
+                  name="password"
                   type="password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   required
                   minLength={8}
+                  autoComplete="new-password"
+                  aria-invalid={Boolean(error)}
+                  aria-describedby={error ? 'register-form-error' : undefined}
                   className="w-full px-4 py-3 rounded-xl border border-navy-200 bg-white text-navy-900 placeholder-navy-300 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 focus:border-emerald-500"
                   placeholder="Min 8 chars, uppercase, lowercase, number"
                 />

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1,12 +1,14 @@
 // src/services/api.js
 import axios from 'axios';
 import { getApiBaseUrl } from '../config/runtime';
+import { shouldAttemptTokenRefresh } from './authInterceptor';
+import { CHAT_REQUEST_TIMEOUT_MS, DEFAULT_API_TIMEOUT_MS } from './requestTimeouts';
 
 const API_BASE = getApiBaseUrl();
 
 const api = axios.create({
   baseURL: API_BASE,
-  timeout: 30000,
+  timeout: DEFAULT_API_TIMEOUT_MS,
   headers: { 'Content-Type': 'application/json' },
 });
 
@@ -25,7 +27,7 @@ api.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
 
-    if (error.response?.status === 401 && !originalRequest._retry) {
+    if (shouldAttemptTokenRefresh(error)) {
       originalRequest._retry = true;
 
       try {
@@ -72,7 +74,7 @@ export const authAPI = {
 // Chat needs a longer timeout because the HF Space model can take 30-120s
 // on cold start (ZeroGPU queue + inference).
 export const chatAPI = {
-  sendMessage: (message, session_id) => api.post('/chat', { message, session_id }, { timeout: 150000 }),
+  sendMessage: (message, session_id) => api.post('/chat', { message, session_id }, { timeout: CHAT_REQUEST_TIMEOUT_MS }),
   getHistory: (params) => api.get('/chat/history', { params }),
   getSessions: () => api.get('/chat/sessions'),
 };

--- a/client/src/services/authInterceptor.js
+++ b/client/src/services/authInterceptor.js
@@ -1,0 +1,30 @@
+const AUTH_ENTRY_PATH_PREFIXES = [
+  '/auth/login',
+  '/auth/google',
+  '/auth/register/',
+  '/auth/forgot-password/',
+];
+
+const getRequestPathname = (url = '') => {
+  try {
+    return new URL(url, 'http://localhost').pathname;
+  } catch {
+    return String(url).split('?')[0];
+  }
+};
+
+export const isAuthEntryEndpoint = (url) => {
+  const pathname = getRequestPathname(url);
+  return AUTH_ENTRY_PATH_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(prefix));
+};
+
+export const shouldAttemptTokenRefresh = (error) => {
+  const originalRequest = error?.config;
+
+  return Boolean(
+    error?.response?.status === 401
+    && originalRequest
+    && !originalRequest._retry
+    && !isAuthEntryEndpoint(originalRequest.url)
+  );
+};

--- a/client/src/services/requestTimeouts.js
+++ b/client/src/services/requestTimeouts.js
@@ -1,0 +1,3 @@
+export const DEFAULT_API_TIMEOUT_MS = 30000;
+// Aligned to the current custom HF server budget: 30s request start + 120s stream.
+export const CHAT_REQUEST_TIMEOUT_MS = 150000;

--- a/client/src/utils/chatResponse.js
+++ b/client/src/utils/chatResponse.js
@@ -1,0 +1,26 @@
+export const getChatErrorMessage = (error) => {
+  const responseError = error?.response?.data?.error;
+  if (typeof responseError === 'string' && responseError.trim()) {
+    return responseError.trim();
+  }
+
+  const responseMessage = error?.response?.data?.message;
+  if (typeof responseMessage === 'string' && responseMessage.trim()) {
+    return responseMessage.trim();
+  }
+
+  const requestMessage = error?.message;
+  if (typeof requestMessage === 'string' && requestMessage.trim() && requestMessage !== 'Network Error') {
+    return requestMessage.trim();
+  }
+
+  return 'Something went wrong. Please try again.';
+};
+
+export const getAssistantMessageContent = (result) => {
+  if (result?.needs_clarification && typeof result?.clarification_question === 'string' && result.clarification_question.trim()) {
+    return result.clarification_question.trim();
+  }
+
+  return result?.response || '';
+};

--- a/client/src/utils/paginatedResponse.js
+++ b/client/src/utils/paginatedResponse.js
@@ -1,0 +1,17 @@
+export const getPaginatedItems = (response, collectionKey) => {
+  const payload = response?.data;
+
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (collectionKey && Array.isArray(payload?.[collectionKey])) {
+    return payload[collectionKey];
+  }
+
+  return [];
+};
+
+export const getPaginatedTotalPages = (response) => {
+  return response?.pagination?.totalPages || response?.data?.pagination?.totalPages || 1;
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-lifesync_root_2025}
       MYSQL_DATABASE: ${DB_NAME:-lifesync_db}
       MYSQL_USER: ${DB_USER:-lifesync}
-      MYSQL_PASSWORD: ${DB_PASS:-lifesync_pass_2025}
+      MYSQL_PASSWORD: ${DB_PASSWORD:-lifesync_pass_2025}
     ports:
       - "3306:3306"
     volumes:
@@ -46,7 +46,7 @@ services:
       DB_PORT: 3306
       DB_NAME: ${DB_NAME:-lifesync_db}
       DB_USER: ${DB_USER:-lifesync}
-      DB_PASS: ${DB_PASS:-lifesync_pass_2025}
+      DB_PASSWORD: ${DB_PASSWORD:-lifesync_pass_2025}
       JWT_SECRET: ${JWT_SECRET:-change_this_in_production_at_least_32_chars}
       JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET:-change_this_refresh_secret_also_32_chars}
       AI_PROVIDER: ${AI_PROVIDER:-gemini}

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "jest": "^30.2.0",
         "nodemon": "^3.1.11",
         "sequelize-cli": "^6.6.5",
+        "supertest": "^7.1.4",
         "wrangler": "^4.78.0"
       }
     },
@@ -3632,6 +3633,19 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@one-ini/wasm": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
@@ -3647,6 +3661,16 @@
       "optional": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -4481,6 +4505,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -5167,6 +5198,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5231,6 +5272,13 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -5380,6 +5428,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dotenv": {
@@ -5864,6 +5923,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-xml-builder": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
@@ -6116,6 +6182,24 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -8076,6 +8160,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -10012,6 +10106,55 @@
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -8,13 +8,18 @@
     "dev": "nodemon server/app.js",
     "install:client": "npm --prefix client ci",
     "build:client": "npm run install:client && npm --prefix client run build",
+    "preflight:release-env": "node scripts/validate-release-env.mjs",
+    "probe:external": "node scripts/probe-external-services.mjs",
+    "smoke:workers": "node scripts/smoke-workers.mjs",
+    "test:e2e:mysql": "jest --runInBand --runTestsByPath tests/e2e/mysql.e2e.test.js --forceExit --detectOpenHandles",
+    "db:wait": "node scripts/wait-for-mysql.js",
     "seed": "node server/seeders/seed.js",
     "migrate": "npx sequelize-cli db:migrate",
     "migrate:undo": "npx sequelize-cli db:migrate:undo:all",
     "test": "jest --verbose --forceExit",
     "test:watch": "jest --watch",
-    "deploy": "npm run build:client && wrangler deploy",
-    "preview": "npm run build:client && wrangler versions upload",
+    "deploy": "npm run preflight:release-env && npm run build:client && wrangler deploy",
+    "preview": "npm run preflight:release-env && npm run build:client && wrangler versions upload",
     "worker:dev": "wrangler dev"
   },
   "keywords": [
@@ -64,6 +69,7 @@
     "jest": "^30.2.0",
     "nodemon": "^3.1.11",
     "sequelize-cli": "^6.6.5",
+    "supertest": "^7.1.4",
     "wrangler": "^4.78.0"
   }
 }

--- a/scripts/probe-external-services.mjs
+++ b/scripts/probe-external-services.mjs
@@ -1,0 +1,130 @@
+const RAILWAY_HEALTH_URL =
+  process.env.RAILWAY_HEALTH_URL || 'https://lifesync-production-6f3e.up.railway.app/api/health';
+const HF_SPACE_URL =
+  (process.env.HF_SPACE_URL || 'https://os-1202883-lifesync-api.hf.space').replace(/\/+$/, '');
+const HF_TIMEOUT_MS = Number(process.env.HF_PROBE_TIMEOUT_MS || 120000);
+const REQUEST_TIMEOUT_MS = Number(process.env.PROBE_REQUEST_TIMEOUT_MS || 30000);
+
+const withTimeout = async (url, options = {}, timeoutMs = REQUEST_TIMEOUT_MS) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const probeRailway = async () => {
+  const response = await withTimeout(RAILWAY_HEALTH_URL);
+  assert(response.ok, `Railway health check failed with status ${response.status}`);
+
+  const payload = await response.json();
+  assert(payload?.success === true, 'Railway health check payload is missing success=true');
+  console.log(`[probe] Railway OK: ${RAILWAY_HEALTH_URL}`);
+};
+
+const parseSseCompletionPayload = (text) => {
+  const lines = text.split(/\r?\n/);
+  let currentEvent = '';
+  const dataLines = [];
+
+  for (const line of lines) {
+    if (line.startsWith('event:')) {
+      currentEvent = line.slice('event:'.length).trim();
+      continue;
+    }
+
+    if (line.startsWith('data:')) {
+      dataLines.push({
+        event: currentEvent,
+        value: line.slice('data:'.length).trim(),
+      });
+    }
+  }
+
+  const completion = dataLines.find((entry) => entry.event === 'complete');
+  if (!completion) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(completion.value);
+    return Array.isArray(parsed) ? parsed[0] : null;
+  } catch {
+    return null;
+  }
+};
+
+const probeHfSpace = async () => {
+  const infoUrl = `${HF_SPACE_URL}/gradio_api/info`;
+  const infoResponse = await withTimeout(infoUrl);
+  assert(infoResponse.ok, `HF info endpoint failed with status ${infoResponse.status}`);
+
+  const infoPayload = await infoResponse.json();
+  assert(
+    Boolean(infoPayload?.named_endpoints?.['/infer']),
+    'HF info payload is missing /infer endpoint metadata'
+  );
+
+  const startResponse = await withTimeout(
+    `${HF_SPACE_URL}/gradio_api/call/infer`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        data: [
+          'Return JSON only.',
+          'I spent $5 on tea',
+          0.1,
+          256,
+        ],
+      }),
+    },
+    REQUEST_TIMEOUT_MS
+  );
+  assert(startResponse.ok, `HF infer call failed with status ${startResponse.status}`);
+
+  const startPayload = await startResponse.json();
+  const eventId = startPayload?.event_id;
+  assert(eventId, 'HF infer call did not return event_id');
+
+  const completionResponse = await withTimeout(
+    `${HF_SPACE_URL}/gradio_api/call/infer/${eventId}`,
+    {},
+    HF_TIMEOUT_MS
+  );
+  assert(
+    completionResponse.ok,
+    `HF infer completion stream failed with status ${completionResponse.status}`
+  );
+
+  const streamText = await completionResponse.text();
+  const completionPayload = parseSseCompletionPayload(streamText);
+  assert(completionPayload && String(completionPayload).trim(), 'HF infer completion payload is empty');
+
+  console.log(`[probe] Hugging Face OK: ${HF_SPACE_URL}`);
+};
+
+const main = async () => {
+  await probeRailway();
+  await probeHfSpace();
+  console.log('[probe] External dependency probes passed.');
+};
+
+main().catch((error) => {
+  console.error(`[probe] ${error.message}`);
+  process.exit(1);
+});

--- a/scripts/smoke-workers.mjs
+++ b/scripts/smoke-workers.mjs
@@ -1,0 +1,74 @@
+const WORKERS_BASE_URL =
+  (process.env.WORKERS_BASE_URL || 'https://lifesync.1202883.workers.dev').replace(/\/+$/, '');
+const RAILWAY_HEALTH_URL =
+  process.env.RAILWAY_HEALTH_URL || 'https://lifesync-production-6f3e.up.railway.app/api/health';
+const ROUTES = ['/login', '/dashboard', '/chat', '/health', '/finance'];
+const REQUEST_TIMEOUT_MS = Number(process.env.SMOKE_TIMEOUT_MS || 30000);
+
+const withTimeout = async (url, timeoutMs = REQUEST_TIMEOUT_MS) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const smokeFrontendRoute = async (route) => {
+  const url = `${WORKERS_BASE_URL}${route}`;
+  const response = await withTimeout(url);
+  assert(response.ok, `Route ${route} failed with status ${response.status}`);
+
+  const html = await response.text();
+  assert(
+    html.includes('<div id="root"></div>'),
+    `Route ${route} did not return SPA shell content`
+  );
+
+  return { route, status: response.status };
+};
+
+const readAssetHash = async () => {
+  const response = await withTimeout(`${WORKERS_BASE_URL}/`);
+  assert(response.ok, `Root route failed with status ${response.status}`);
+
+  const html = await response.text();
+  const scriptMatch = html.match(/\/assets\/index-([A-Za-z0-9_-]+)\.js/);
+  assert(scriptMatch, 'Unable to extract index asset hash from production HTML');
+
+  return scriptMatch[1];
+};
+
+const smokeRailway = async () => {
+  const response = await withTimeout(RAILWAY_HEALTH_URL);
+  assert(response.ok, `Railway health failed with status ${response.status}`);
+
+  const payload = await response.json();
+  assert(payload?.success === true, 'Railway health payload is missing success=true');
+};
+
+const main = async () => {
+  for (const route of ROUTES) {
+    await smokeFrontendRoute(route);
+    console.log(`[smoke] ${WORKERS_BASE_URL}${route} OK`);
+  }
+
+  await smokeRailway();
+  console.log(`[smoke] Railway health OK: ${RAILWAY_HEALTH_URL}`);
+
+  const hash = await readAssetHash();
+  console.log(`[smoke] Active production asset hash: ${hash}`);
+};
+
+main().catch((error) => {
+  console.error(`[smoke] ${error.message}`);
+  process.exit(1);
+});

--- a/scripts/validate-release-env.mjs
+++ b/scripts/validate-release-env.mjs
@@ -1,0 +1,74 @@
+const REQUIRED = [
+  'VITE_API_URL',
+  'VITE_GOOGLE_CLIENT_ID',
+  'GOOGLE_AUTH_CLIENT_IDS',
+];
+
+const EXPECTED_API_URL =
+  process.env.EXPECTED_VITE_API_URL
+  || 'https://lifesync-production-6f3e.up.railway.app/api';
+const EXPECTED_GOOGLE_CLIENT_ID =
+  process.env.EXPECTED_VITE_GOOGLE_CLIENT_ID
+  || '123174641248-1grp7s1u20ad1d3olkpg28hfe723rkut.apps.googleusercontent.com';
+const GOOGLE_CLIENT_ID_PATTERN = /^[0-9]{12}-[a-z0-9-]+\.apps\.googleusercontent\.com$/i;
+
+let hasFailures = false;
+
+const fail = (message) => {
+  hasFailures = true;
+  console.error(`[release-preflight] ${message}`);
+};
+
+const get = (key) => (process.env[key] || '').trim();
+
+for (const key of REQUIRED) {
+  if (!get(key)) {
+    fail(`Missing required environment variable: ${key}`);
+  }
+}
+
+const apiUrl = get('VITE_API_URL');
+if (apiUrl) {
+  try {
+    const parsed = new URL(apiUrl);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      fail(`VITE_API_URL must use http/https: ${apiUrl}`);
+    }
+  } catch {
+    fail(`VITE_API_URL must be an absolute URL: ${apiUrl}`);
+  }
+
+  if (apiUrl !== EXPECTED_API_URL) {
+    fail(`VITE_API_URL must equal ${EXPECTED_API_URL}, got ${apiUrl}`);
+  }
+}
+
+const googleClientId = get('VITE_GOOGLE_CLIENT_ID');
+if (googleClientId) {
+  if (!GOOGLE_CLIENT_ID_PATTERN.test(googleClientId)) {
+    fail(`VITE_GOOGLE_CLIENT_ID is malformed: ${googleClientId}`);
+  }
+
+  if (googleClientId !== EXPECTED_GOOGLE_CLIENT_ID) {
+    fail(
+      `VITE_GOOGLE_CLIENT_ID must equal ${EXPECTED_GOOGLE_CLIENT_ID}, got ${googleClientId}`
+    );
+  }
+}
+
+const backendClientIds = get('GOOGLE_AUTH_CLIENT_IDS')
+  .split(',')
+  .map((value) => value.trim())
+  .filter(Boolean);
+
+if (backendClientIds.length && !backendClientIds.includes(EXPECTED_GOOGLE_CLIENT_ID)) {
+  fail(
+    `GOOGLE_AUTH_CLIENT_IDS must include ${EXPECTED_GOOGLE_CLIENT_ID} for frontend/backend alignment.`
+  );
+}
+
+if (hasFailures) {
+  process.exit(1);
+}
+
+console.log('[release-preflight] Environment validation passed.');

--- a/scripts/validate-release-env.mjs
+++ b/scripts/validate-release-env.mjs
@@ -1,7 +1,6 @@
 const REQUIRED = [
   'VITE_API_URL',
   'VITE_GOOGLE_CLIENT_ID',
-  'GOOGLE_AUTH_CLIENT_IDS',
 ];
 
 const EXPECTED_API_URL =
@@ -11,6 +10,7 @@ const EXPECTED_GOOGLE_CLIENT_ID =
   process.env.EXPECTED_VITE_GOOGLE_CLIENT_ID
   || '123174641248-1grp7s1u20ad1d3olkpg28hfe723rkut.apps.googleusercontent.com';
 const GOOGLE_CLIENT_ID_PATTERN = /^[0-9]{12}-[a-z0-9-]+\.apps\.googleusercontent\.com$/i;
+const REQUIRE_BACKEND_ALIGNMENT = getBooleanEnv('REQUIRE_BACKEND_GOOGLE_ALIGNMENT');
 
 let hasFailures = false;
 
@@ -20,6 +20,10 @@ const fail = (message) => {
 };
 
 const get = (key) => (process.env[key] || '').trim();
+function getBooleanEnv(key) {
+  const value = (process.env[key] || '').trim().toLowerCase();
+  return ['1', 'true', 'yes', 'on'].includes(value);
+}
 
 for (const key of REQUIRED) {
   if (!get(key)) {
@@ -56,15 +60,23 @@ if (googleClientId) {
   }
 }
 
-const backendClientIds = get('GOOGLE_AUTH_CLIENT_IDS')
-  .split(',')
-  .map((value) => value.trim())
-  .filter(Boolean);
+const backendClientIdsRaw = get('GOOGLE_AUTH_CLIENT_IDS');
 
-if (backendClientIds.length && !backendClientIds.includes(EXPECTED_GOOGLE_CLIENT_ID)) {
-  fail(
-    `GOOGLE_AUTH_CLIENT_IDS must include ${EXPECTED_GOOGLE_CLIENT_ID} for frontend/backend alignment.`
-  );
+if (!backendClientIdsRaw && REQUIRE_BACKEND_ALIGNMENT) {
+  fail('Missing required environment variable: GOOGLE_AUTH_CLIENT_IDS');
+}
+
+if (backendClientIdsRaw) {
+  const backendClientIds = backendClientIdsRaw
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  if (!backendClientIds.includes(EXPECTED_GOOGLE_CLIENT_ID)) {
+    fail(
+      `GOOGLE_AUTH_CLIENT_IDS must include ${EXPECTED_GOOGLE_CLIENT_ID} for frontend/backend alignment.`
+    );
+  }
 }
 
 if (hasFailures) {

--- a/scripts/wait-for-mysql.js
+++ b/scripts/wait-for-mysql.js
@@ -1,0 +1,43 @@
+const mysql = require('mysql2/promise');
+
+const host = process.env.DB_HOST || '127.0.0.1';
+const port = Number(process.env.DB_PORT || 3306);
+const user = process.env.DB_USER || 'root';
+const password = process.env.DB_PASSWORD || '';
+const database = process.env.DB_NAME || '';
+const maxAttempts = Number(process.env.MYSQL_WAIT_MAX_ATTEMPTS || 30);
+const delayMs = Number(process.env.MYSQL_WAIT_DELAY_MS || 2000);
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const main = async () => {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const connection = await mysql.createConnection({
+        host,
+        port,
+        user,
+        password,
+        database,
+      });
+      await connection.query('SELECT 1');
+      await connection.end();
+      console.log(`[mysql-wait] MySQL is ready on attempt ${attempt}.`);
+      return;
+    } catch (error) {
+      const suffix = attempt === maxAttempts ? ' (final attempt)' : '';
+      console.log(
+        `[mysql-wait] Attempt ${attempt}/${maxAttempts} failed${suffix}: ${error.message}`
+      );
+      if (attempt === maxAttempts) {
+        throw error;
+      }
+      await sleep(delayMs);
+    }
+  }
+};
+
+main().catch((error) => {
+  console.error(`[mysql-wait] MySQL readiness check failed: ${error.message}`);
+  process.exit(1);
+});

--- a/tests/authInterceptor.test.js
+++ b/tests/authInterceptor.test.js
@@ -1,0 +1,27 @@
+import { shouldAttemptTokenRefresh } from '../client/src/services/authInterceptor';
+
+describe('auth interceptor 401 handling', () => {
+  it('does not attempt token refresh for invalid login responses', () => {
+    const error = {
+      response: { status: 401, data: { error: 'Invalid email or password' } },
+      config: {
+        url: '/auth/login',
+        _retry: false,
+      },
+    };
+
+    expect(shouldAttemptTokenRefresh(error)).toBe(false);
+  });
+
+  it('still attempts token refresh for protected API requests', () => {
+    const error = {
+      response: { status: 401, data: { error: 'Access denied' } },
+      config: {
+        url: '/health-logs?page=1',
+        _retry: false,
+      },
+    };
+
+    expect(shouldAttemptTokenRefresh(error)).toBe(true);
+  });
+});

--- a/tests/chatResponse.test.js
+++ b/tests/chatResponse.test.js
@@ -1,0 +1,38 @@
+import {
+  getAssistantMessageContent,
+  getChatErrorMessage,
+} from '../client/src/utils/chatResponse';
+import {
+  CHAT_REQUEST_TIMEOUT_MS,
+  DEFAULT_API_TIMEOUT_MS,
+} from '../client/src/services/requestTimeouts';
+
+describe('chat response helpers', () => {
+  it('prefers backend error text when the API returns an error field', () => {
+    const error = {
+      response: {
+        data: {
+          success: false,
+          error: 'HF Space unavailable right now.',
+        },
+      },
+    };
+
+    expect(getChatErrorMessage(error)).toBe('HF Space unavailable right now.');
+  });
+
+  it('shows the clarification question when the backend asks a follow-up', () => {
+    const result = {
+      response: 'I need a bit more detail before I log that.',
+      needs_clarification: true,
+      clarification_question: 'Would you like me to log this as a $50 gym expense, 50 minutes of exercise, or both?',
+      clarification_options: ['Gym expense', 'Exercise', 'Both'],
+    };
+
+    expect(getAssistantMessageContent(result)).toBe(result.clarification_question);
+  });
+
+  it('uses a longer timeout for chat requests than the shared API default', () => {
+    expect(CHAT_REQUEST_TIMEOUT_MS).toBeGreaterThan(DEFAULT_API_TIMEOUT_MS);
+  });
+});

--- a/tests/e2e/mysql.e2e.test.js
+++ b/tests/e2e/mysql.e2e.test.js
@@ -19,19 +19,21 @@ const {
 } = db;
 
 const truncateAllTables = async () => {
-  await sequelize.query('SET FOREIGN_KEY_CHECKS = 0');
-  await Promise.all([
-    LinkedDomain.destroy({ where: {}, truncate: true, force: true }),
-    HealthLog.destroy({ where: {}, truncate: true, force: true }),
-    FinancialLog.destroy({ where: {}, truncate: true, force: true }),
-    AISummary.destroy({ where: {}, truncate: true, force: true }),
-    ChatLog.destroy({ where: {}, truncate: true, force: true }),
-    UserGoal.destroy({ where: {}, truncate: true, force: true }),
-    SystemLog.destroy({ where: {}, truncate: true, force: true }),
-    Category.destroy({ where: {}, truncate: true, force: true }),
-    User.destroy({ where: {}, truncate: true, force: true }),
-  ]);
-  await sequelize.query('SET FOREIGN_KEY_CHECKS = 1');
+  const deleteOrder = [
+    LinkedDomain,
+    HealthLog,
+    FinancialLog,
+    AISummary,
+    ChatLog,
+    UserGoal,
+    SystemLog,
+    Category,
+    User,
+  ];
+
+  for (const model of deleteOrder) {
+    await model.destroy({ where: {}, force: true });
+  }
 };
 
 suite('MySQL E2E: auth + health + finance', () => {

--- a/tests/e2e/mysql.e2e.test.js
+++ b/tests/e2e/mysql.e2e.test.js
@@ -1,0 +1,122 @@
+const request = require('supertest');
+const { app } = require('../../server/app');
+const db = require('../../server/models');
+
+const shouldRun = process.env.RUN_DB_E2E === 'true';
+const suite = shouldRun ? describe : describe.skip;
+
+const {
+  sequelize,
+  User,
+  Category,
+  HealthLog,
+  FinancialLog,
+  LinkedDomain,
+  AISummary,
+  ChatLog,
+  UserGoal,
+  SystemLog,
+} = db;
+
+const truncateAllTables = async () => {
+  await sequelize.query('SET FOREIGN_KEY_CHECKS = 0');
+  await Promise.all([
+    LinkedDomain.destroy({ where: {}, truncate: true, force: true }),
+    HealthLog.destroy({ where: {}, truncate: true, force: true }),
+    FinancialLog.destroy({ where: {}, truncate: true, force: true }),
+    AISummary.destroy({ where: {}, truncate: true, force: true }),
+    ChatLog.destroy({ where: {}, truncate: true, force: true }),
+    UserGoal.destroy({ where: {}, truncate: true, force: true }),
+    SystemLog.destroy({ where: {}, truncate: true, force: true }),
+    Category.destroy({ where: {}, truncate: true, force: true }),
+    User.destroy({ where: {}, truncate: true, force: true }),
+  ]);
+  await sequelize.query('SET FOREIGN_KEY_CHECKS = 1');
+};
+
+suite('MySQL E2E: auth + health + finance', () => {
+  let token = '';
+  const credentials = {
+    email: 'mysql-e2e-user@example.com',
+    password: 'Password123',
+  };
+
+  beforeAll(async () => {
+    await sequelize.authenticate();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables();
+
+    await User.create({
+      username: 'mysql_e2e_user',
+      email: credentials.email,
+      hashed_password: credentials.password,
+      verified_email: true,
+      is_active: true,
+    });
+
+    const loginResponse = await request(app)
+      .post('/api/auth/login')
+      .send(credentials);
+
+    expect(loginResponse.status).toBe(200);
+    expect(loginResponse.body?.data?.accessToken).toBeTruthy();
+    token = loginResponse.body.data.accessToken;
+  });
+
+  afterAll(async () => {
+    await sequelize.close();
+  });
+
+  test('logs and retrieves health records against a real MySQL database', async () => {
+    const createResponse = await request(app)
+      .post('/api/health-logs')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        type: 'steps',
+        value: 4200,
+        notes: 'Morning walk',
+      });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body?.data?.entry?.type).toBe('steps');
+    expect(Number(createResponse.body?.data?.entry?.value)).toBe(4200);
+
+    const listResponse = await request(app)
+      .get('/api/health-logs')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(listResponse.status).toBe(200);
+    expect(Array.isArray(listResponse.body?.data)).toBe(true);
+    expect(listResponse.body.data).toHaveLength(1);
+    expect(listResponse.body?.pagination?.total).toBe(1);
+    expect(listResponse.body.data[0].type).toBe('steps');
+  });
+
+  test('logs and retrieves finance records against a real MySQL database', async () => {
+    const createResponse = await request(app)
+      .post('/api/finance')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        type: 'expense',
+        amount: 25.5,
+        currency: 'USD',
+        description: 'Lunch',
+      });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body?.data?.entry?.type).toBe('expense');
+    expect(Number(createResponse.body?.data?.entry?.amount)).toBe(25.5);
+
+    const listResponse = await request(app)
+      .get('/api/finance')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(listResponse.status).toBe(200);
+    expect(Array.isArray(listResponse.body?.data)).toBe(true);
+    expect(listResponse.body.data).toHaveLength(1);
+    expect(listResponse.body?.pagination?.total).toBe(1);
+    expect(listResponse.body.data[0].type).toBe('expense');
+  });
+});

--- a/tests/googleSignInState.test.js
+++ b/tests/googleSignInState.test.js
@@ -1,0 +1,14 @@
+import {
+  buildGoogleButtonRenderKey,
+  shouldInitializeGoogleIdentity,
+} from '../client/src/components/auth/googleSignInState';
+
+describe('google sign-in lifecycle helpers', () => {
+  it('does not request another initialize call for the same client id', () => {
+    expect(shouldInitializeGoogleIdentity('client-id', 'client-id')).toBe(false);
+  });
+
+  it('keeps button render keys stable for the same client and button text', () => {
+    expect(buildGoogleButtonRenderKey('client-id', 'signin_with')).toBe('client-id:signin_with');
+  });
+});

--- a/tests/insightCardModel.test.js
+++ b/tests/insightCardModel.test.js
@@ -1,0 +1,27 @@
+import { getInsightCardsViewModel } from '../client/src/components/dashboard/insightCardModel';
+
+describe('insight card model', () => {
+  it('does not fabricate demo insights when the insights request fails', () => {
+    const view = getInsightCardsViewModel({
+      insights: null,
+      error: 'Insights service unavailable',
+    });
+
+    expect(view.kind).toBe('error');
+    expect(view.data).toBeNull();
+    expect(view.error).toBe('Insights service unavailable');
+  });
+
+  it('returns real insight data when available', () => {
+    const insights = {
+      summary: 'Real backend summary',
+      recommendations: [{ text: 'Real recommendation' }],
+    };
+
+    const view = getInsightCardsViewModel({ insights, error: null });
+
+    expect(view.kind).toBe('data');
+    expect(view.data).toBe(insights);
+    expect(view.error).toBeNull();
+  });
+});

--- a/tests/paginatedResponse.test.js
+++ b/tests/paginatedResponse.test.js
@@ -1,0 +1,45 @@
+import {
+  getPaginatedItems,
+  getPaginatedTotalPages,
+} from '../client/src/utils/paginatedResponse';
+
+describe('paginatedResponse helpers', () => {
+  it('reads the top-level array and pagination shape emitted by responseHelper.paginated', () => {
+    const response = {
+      success: true,
+      message: 'Success',
+      data: [
+        { id: 1, type: 'steps', value: 3200 },
+        { id: 2, type: 'sleep', value: 7.5 },
+      ],
+      pagination: {
+        page: 1,
+        limit: 20,
+        total: 2,
+        totalPages: 3,
+      },
+    };
+
+    expect(getPaginatedItems(response, 'logs')).toEqual(response.data);
+    expect(getPaginatedTotalPages(response)).toBe(3);
+  });
+
+  it('keeps working with the legacy nested shape used by the current client', () => {
+    const response = {
+      success: true,
+      message: 'Success',
+      data: {
+        logs: [{ id: 10, type: 'expense', amount: 42.5 }],
+        pagination: {
+          page: 1,
+          limit: 20,
+          total: 1,
+          totalPages: 2,
+        },
+      },
+    };
+
+    expect(getPaginatedItems(response, 'logs')).toEqual(response.data.logs);
+    expect(getPaginatedTotalPages(response)).toBe(2);
+  });
+});

--- a/tests/runtimeConfig.test.js
+++ b/tests/runtimeConfig.test.js
@@ -1,0 +1,22 @@
+import { resolveRuntimeConfig } from '../client/src/config/runtimeConfig';
+
+describe('runtime config', () => {
+  it('does not silently bake hidden production API or Google defaults when env is missing', () => {
+    expect(resolveRuntimeConfig({ DEV: false, PROD: true })).toEqual({
+      apiBaseUrl: '/api',
+      googleClientId: '',
+      warnings: [
+        'VITE_API_URL is not set for this production build. Falling back to same-origin /api.',
+        'VITE_GOOGLE_CLIENT_ID is not set for this production build. Google sign-in is disabled.',
+      ],
+    });
+  });
+
+  it('keeps the dev proxy default when no explicit API URL is provided locally', () => {
+    expect(resolveRuntimeConfig({ DEV: true, PROD: false })).toEqual({
+      apiBaseUrl: '/api',
+      googleClientId: '',
+      warnings: [],
+    });
+  });
+});


### PR DESCRIPTION
## What changed
- switched chat provider resolution to support feature-specific routing with `CHAT_AI_PROVIDER` and `INSIGHTS_AI_PROVIDER`
- replaced the stale custom Hugging Face `/run/predict` call with the live Gradio queue/SSE flow used by the deployed Space
- kept weekly insights on the non-HF provider path while switching chat to the LifeSync HF Space
- added a compact custom-HF chat prompt and normalization aliases so the current model output still maps into LifeSync's expected chat entity contract
- updated `.env.example`, README, and test coverage for the new provider behavior

## Why it changed
The deployed Hugging Face Space no longer serves the older `/run/predict` contract. The backend needed to call the Space through its current Gradio `6.x` API while keeping the public `/api/chat` interface unchanged.

## User and developer impact
- chat requests can now run through `https://os-1202883-lifesync-api.hf.space` by setting `CHAT_AI_PROVIDER=custom_hf`
- weekly insights can stay on Gemini or another provider by setting `INSIGHTS_AI_PROVIDER`
- `HF_API_KEY` is optional for the public Space flow and is only sent when configured

## Validation
- `npm test -- --runTestsByPath tests/providerClient.test.js tests/nlp.test.js --forceExit`
- `npm test -- --forceExit`
- live provider probe against the HF Space through `generateStructuredJson(...)`
- live `parseMessage('I spent $20 on coffee')` probe through `nlpService`

## Notes
- the current HF Space works with the patched adapter, but observed live latency is still high on the current Space runtime
- this PR intentionally leaves weekly insights on the existing non-HF provider path