### PR TITLE
fix(db): surface real cause of MySQL connection failures

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -46,11 +46,27 @@ const sequelize = new Sequelize(
  * Test the database connection
  */
 const testConnection = async () => {
+  if (dialect === 'mysql' && !process.env.DB_HOST) {
+    console.error(
+      '❌ DB_HOST is not set. On a host like Railway, map the MySQL plugin ' +
+      'variables to the DB_* names this app expects, e.g. ' +
+      'DB_HOST=${{MySQL.MYSQLHOST}}, DB_USER, DB_PASSWORD, DB_NAME, DB_PORT.'
+    );
+    process.exit(1);
+  }
+
   try {
     await sequelize.authenticate();
     console.log(`✅ ${dialect.toUpperCase()} connection established successfully.`);
   } catch (error) {
-    console.error(`❌ Unable to connect to ${dialect}:`, error.message);
+    // Surface the real cause — message is often empty for a bad/undefined host.
+    console.error(`❌ Unable to connect to ${dialect}: ${error.message || error.code || error}`);
+    if (dialect === 'mysql') {
+      console.error(
+        `   tried host=${process.env.DB_HOST} port=${process.env.DB_PORT || 3306} ` +
+        `db=${process.env.DB_NAME} user=${process.env.DB_USER}`
+      );
+    }
     process.exit(1);
   }
 };


### PR DESCRIPTION
## Summary

Diagnostics-only. The Railway deploy crash-looped with a blank
`❌ Unable to connect to mysql:` and no cause. `testConnection` logged only
`error.message`, which is empty when `DB_HOST` is undefined.

Now:
- Fails fast with an explicit hint if `DB_HOST` is unset (the Railway
  MySQL-plugin → `DB_*` mapping was missing).
- Otherwise logs `error.code` and the `host/port/db/user` it tried (no secrets).

## Not the root cause
The crash itself is **config**, not code: the Railway service was missing the
`DB_*` variables. Fix on Railway:
```
DB_HOST=${{MySQL.MYSQLHOST}}
DB_PORT=${{MySQL.MYSQLPORT}}
DB_USER=${{MySQL.MYSQLUSER}}
DB_PASSWORD=${{MySQL.MYSQLPASSWORD}}
DB_NAME=${{MySQL.MYSQLDATABASE}}
```
This PR just makes the next failure self-explanatory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)