### PR TITLE
chore(frontend): point production API at new Railway backend (fdf9)

### DIFF
--- a/client/.env.production
+++ b/client/.env.production
@@ -3,5 +3,5 @@
 # ID* are both embedded into the shipped bundle anyway. No secrets here.
 # Vite auto-loads this file during `vite build`; the build preflight reads it too.
 # Override per-environment by setting the same vars in the build environment.
-VITE_API_URL=https://lifesync-production-6f3e.up.railway.app/api
+VITE_API_URL=https://lifesync-production-fdf9.up.railway.app/api
 VITE_GOOGLE_CLIENT_ID=190237143688-0ddtrdq3die8hnce0aqbti3jgc2eam4g.apps.googleusercontent.com

--- a/client/scripts/validateBuildEnv.mjs
+++ b/client/scripts/validateBuildEnv.mjs
@@ -32,7 +32,7 @@ const REQUIRED = [
 const EXPECTED = {
   VITE_API_URL:
     process.env.EXPECTED_VITE_API_URL
-    || 'https://lifesync-production-6f3e.up.railway.app/api',
+    || 'https://lifesync-production-fdf9.up.railway.app/api',
   VITE_GOOGLE_CLIENT_ID:
     process.env.EXPECTED_VITE_GOOGLE_CLIENT_ID
     || '190237143688-0ddtrdq3die8hnce0aqbti3jgc2eam4g.apps.googleusercontent.com',

--- a/scripts/validate-release-env.mjs
+++ b/scripts/validate-release-env.mjs
@@ -30,7 +30,7 @@ const REQUIRED = [
 
 const EXPECTED_API_URL =
   process.env.EXPECTED_VITE_API_URL
-  || 'https://lifesync-production-6f3e.up.railway.app/api';
+  || 'https://lifesync-production-fdf9.up.railway.app/api';
 const EXPECTED_GOOGLE_CLIENT_ID =
   process.env.EXPECTED_VITE_GOOGLE_CLIENT_ID
   || '190237143688-0ddtrdq3die8hnce0aqbti3jgc2eam4g.apps.googleusercontent.com';


### PR DESCRIPTION
## Summary

The old Railway backend (`lifesync-production-6f3e`) was removed and the API
redeployed on a new account at **`lifesync-production-fdf9.up.railway.app`**
(verified live: `GET /api/health` → `{"success":true,...,"version":"2.0.0"}`).

Update the production `VITE_API_URL` so the Cloudflare frontend talks to the
live backend, in all three places that pin it:
- `client/.env.production`
- `client/scripts/validateBuildEnv.mjs` (EXPECTED baseline)
- `scripts/validate-release-env.mjs` (EXPECTED baseline)

Both preflights pass with the new URL.

## Reminder (backend side, Railway)
Set `CORS_ORIGIN` on the `lifesync` service to the Cloudflare frontend URL, or
the browser will block API calls cross-origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)