### PR TITLE
chore(ci): point smoke/probe at new backend URL (fdf9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,7 +116,7 @@ GEMMA4_MODEL=gemma3                  # set to your Gemma 4 tag once pulled
 # BERT_MULTI_LABEL_THRESHOLD=0.60  # retain strong secondary intents
 
 # Frontend build — already defaults to Railway URL; set only to override
-# VITE_API_URL=https://lifesync-production-6f3e.up.railway.app/api
+# VITE_API_URL=https://lifesync-production-fdf9.up.railway.app/api
 
 # --- Encryption ---
 ENCRYPTION_KEY=your_encryption_key_min_32_chars!

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,9 +157,9 @@ jobs:
         working-directory: ./client
         run: npm run build
         env:
-          VITE_API_URL: https://lifesync-production-6f3e.up.railway.app/api
+          VITE_API_URL: https://lifesync-production-fdf9.up.railway.app/api
           VITE_GOOGLE_CLIENT_ID: 190237143688-0ddtrdq3die8hnce0aqbti3jgc2eam4g.apps.googleusercontent.com
-          EXPECTED_VITE_API_URL: https://lifesync-production-6f3e.up.railway.app/api
+          EXPECTED_VITE_API_URL: https://lifesync-production-fdf9.up.railway.app/api
           EXPECTED_VITE_GOOGLE_CLIENT_ID: 190237143688-0ddtrdq3die8hnce0aqbti3jgc2eam4g.apps.googleusercontent.com
 
       - name: Verify build output

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -8,6 +8,12 @@ on:
 jobs:
   release-smoke:
     runs-on: ubuntu-latest
+    env:
+      # Probe the live production services, not the localhost defaults.
+      BACKEND_HEALTH_URL: https://lifesync-production-fdf9.up.railway.app/api/health
+      RAILWAY_HEALTH_URL: https://lifesync-production-fdf9.up.railway.app/api/health
+      WORKERS_BASE_URL: https://lifesync.1202883.workers.dev
+      HF_SPACE_URL: https://os-1202883-lifesync-api.hf.space
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ This repo now includes `wrangler.jsonc` with SPA fallback enabled for Cloudflare
 The `deploy` and `preview` scripts build the frontend before calling Wrangler, so Cloudflare does not need a separate build step.
 Those scripts also install the frontend dependencies inside `client/` before running Vite, because Workers Builds only installs the root package by default.
 Both scripts now run a strict release preflight that validates:
-- `VITE_API_URL=https://lifesync-production-6f3e.up.railway.app/api`
+- `VITE_API_URL=https://lifesync-production-fdf9.up.railway.app/api`
 - `VITE_GOOGLE_CLIENT_ID=190237143688-0ddtrdq3die8hnce0aqbti3jgc2eam4g.apps.googleusercontent.com` (must match the Cloudflare project env var of the same name)
 - if `GOOGLE_AUTH_CLIENT_IDS` is provided, it must include that same Google client ID
 

--- a/scripts/smoke-workers.mjs
+++ b/scripts/smoke-workers.mjs
@@ -1,7 +1,7 @@
 const WORKERS_BASE_URL =
   (process.env.WORKERS_BASE_URL || 'https://lifesync.1202883.workers.dev').replace(/\/+$/, '');
 const RAILWAY_HEALTH_URL =
-  process.env.RAILWAY_HEALTH_URL || 'https://lifesync-production-6f3e.up.railway.app/api/health';
+  process.env.RAILWAY_HEALTH_URL || 'https://lifesync-production-fdf9.up.railway.app/api/health';
 const ROUTES = ['/login', '/dashboard', '/chat', '/health', '/finance'];
 const REQUEST_TIMEOUT_MS = Number(process.env.SMOKE_TIMEOUT_MS || 30000);
 


### PR DESCRIPTION
## Summary

Fixes the red **release-smoke** check and removes every stale `6f3e` reference.

`release-smoke.yml` ran `probe:external` with no env, so `probe-external-services.mjs`
fell back to its `localhost:5000` default and failed with `[probe] fetch failed`
in CI. Now the workflow points the probe + route smoke at the live production
services.

Changes:
- `release-smoke.yml`: set `BACKEND_HEALTH_URL` / `RAILWAY_HEALTH_URL` /
  `WORKERS_BASE_URL` / `HF_SPACE_URL` to live endpoints.
- `scripts/smoke-workers.mjs`: default backend health URL `6f3e` → `fdf9`.
- `.github/workflows/ci.yml`: `build-frontend` env `6f3e` → `fdf9`.
- `.env.example`, `README.md`: doc URL `6f3e` → `fdf9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)