### PR TITLE
fix(otp): log structured SMTP error detail

### DIFF
--- a/server/services/otpService.js
+++ b/server/services/otpService.js
@@ -278,7 +278,16 @@ const sendOTPEmail = async (email, code) => {
       message: 'Verification email sent.',
     };
   } catch (error) {
-    console.error('Email send error:', error.message);
+    // Log the structured nodemailer fields — message alone is often empty or
+    // generic. code=EAUTH + responseCode=535 = bad SMTP_PASS (use a Gmail App
+    // Password); ETIMEDOUT/ECONNECTION = host can't reach the SMTP server.
+    console.error('Email send error:', {
+      message: error.message,
+      code: error.code,
+      responseCode: error.responseCode,
+      command: error.command,
+      response: error.response,
+    });
     if (error.message === 'SMTP is not configured.') {
       return {
         success: false,


### PR DESCRIPTION
Registration returns 503 EMAIL_SEND_FAILED but the catch logged only `error.message`, which is often empty/generic. Now logs the nodemailer structured fields (code, responseCode, command, response) so the Railway log states the exact cause: `EAUTH`/`535` = bad SMTP_PASS (needs Gmail App Password), `ETIMEDOUT`/`ECONNECTION` = host can't reach SMTP. No behavior change to the API response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)