### PR TITLE
feat(otp): send OTP via Resend HTTP API (SMTP blocked on Railway)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -144,8 +144,17 @@ APP_URL=http://localhost:5000
 # --- CORS ---
 CORS_ORIGIN=http://localhost:5173
 
-# --- SMTP (Email for OTP) ---
-# Leave blank to use Ethereal test emails in development
+# --- Email for OTP ---
+# Preferred on hosts that block outbound SMTP (e.g. Railway): Resend HTTP API.
+# When RESEND_API_KEY is set, OTP email is sent via https://api.resend.com
+# (port 443) instead of SMTP. Get a free key at resend.com.
+# RESEND_FROM must be a verified Resend sender; onboarding@resend.dev works for
+# testing but only delivers to your own account email until a domain is verified.
+RESEND_API_KEY=
+RESEND_FROM=LifeSync <onboarding@resend.dev>
+
+# SMTP fallback (used only when RESEND_API_KEY is empty).
+# Leave blank to use Ethereal test emails in development.
 SMTP_HOST=
 SMTP_PORT=587
 SMTP_SECURE=false

--- a/server/services/otpService.js
+++ b/server/services/otpService.js
@@ -232,16 +232,7 @@ const sendOTPEmail = async (email, code) => {
   }
 
   try {
-    const transporter = await createTransporter();
-    if (!transporter) {
-      return { success: true, message: 'OTP logged to console (no email transport).' };
-    }
-
-    const mailOptions = {
-      from: `"${process.env.SMTP_FROM_NAME || 'LifeSync'}" <${process.env.SMTP_FROM_EMAIL || process.env.SMTP_USER || 'noreply@lifesync.app'}>`,
-      to: email,
-      subject: 'LifeSync — Your Verification Code',
-      html: `
+    const html = `
         <div style="font-family: 'Segoe UI', Arial, sans-serif; max-width: 480px; margin: 0 auto; padding: 32px; background: #f8fafc; border-radius: 12px;">
           <div style="text-align: center; margin-bottom: 24px;">
             <h1 style="color: #1e293b; font-size: 24px; margin: 0;">LifeSync</h1>
@@ -262,7 +253,41 @@ const sendOTPEmail = async (email, code) => {
             </p>
           </div>
         </div>
-      `,
+      `;
+    const subject = 'LifeSync — Your Verification Code';
+
+    // Prefer Resend's HTTP API when configured. It sends over HTTPS (443), so
+    // it works on hosts that block outbound SMTP ports — e.g. Railway, where
+    // the SMTP path fails with a connection timeout to smtp.gmail.com:587.
+    if (process.env.RESEND_API_KEY) {
+      const from = process.env.RESEND_FROM
+        || process.env.SMTP_FROM_EMAIL
+        || 'LifeSync <onboarding@resend.dev>';
+      const resendResp = await fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ from, to: [email], subject, html }),
+      });
+      if (!resendResp.ok) {
+        const detail = await resendResp.text().catch(() => '');
+        throw new Error(`Resend API ${resendResp.status}: ${detail.slice(0, 300)}`);
+      }
+      return { success: true, message: 'Verification email sent.' };
+    }
+
+    const transporter = await createTransporter();
+    if (!transporter) {
+      return { success: true, message: 'OTP logged to console (no email transport).' };
+    }
+
+    const mailOptions = {
+      from: `"${process.env.SMTP_FROM_NAME || 'LifeSync'}" <${process.env.SMTP_FROM_EMAIL || process.env.SMTP_USER || 'noreply@lifesync.app'}>`,
+      to: email,
+      subject,
+      html,
     };
 
     const info = await transporter.sendMail(mailOptions);


### PR DESCRIPTION
## Summary

Root cause of registration failing in prod: Railway blocks outbound SMTP — `sendOTPEmail` logged `Email send error: Connection timeout` connecting to `smtp.gmail.com:587`. App Passwords / port changes can't fix a blocked egress.

**Fix:** send OTP email over **HTTP (port 443)** via the Resend API when `RESEND_API_KEY` is set; SMTP stays as the fallback. HTTP is never blocked by PaaS egress rules.

- `server/services/otpService.js`: Resend branch in `sendOTPEmail` (reuses the same HTML), before the SMTP transporter.
- `.env.example`: document `RESEND_API_KEY` + `RESEND_FROM`.

## To activate (Railway env)
1. Free account at resend.com → API key.
2. Set `RESEND_API_KEY` on the `lifesync` service. (Optionally `RESEND_FROM`; defaults to `onboarding@resend.dev` for testing.)
3. Redeploy → registration OTP works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)