### PR TITLE
Arabic NLU: real expense categories, query/goal intents, dual forms

### DIFF
--- a/server/services/ai/bertNlpService.js
+++ b/server/services/ai/bertNlpService.js
@@ -21,6 +21,17 @@ const AR_DIGITS = {
   '۰': '0', '۱': '1', '۲': '2', '۳': '3', '۴': '4', '۵': '5', '۶': '6', '۷': '7', '۸': '8', '۹': '9',
 };
 const AR_LEXICON = [
+  // Phrases FIRST — the verb stems below would otherwise consume their words
+  // (e.g. "كم أنفقت" must become a summary query before أنفق → spent).
+  [/كم\s+(?:أنفقت|انفقت|صرفت|دفعت)/g, ' how much did i spend '],
+  [/ملخص/g, ' summary '],
+  [/أريد أن (?:أدخر|ادخر|أوفر|اوفر)|أريد (?:توفير|ادخار|الادخار)/g, ' i want to save '],
+  [/هدفي|هدف/g, ' goal '],
+  // Dual forms before their singular stems (لترين contains لتر etc.).
+  [/لترين/g, ' 2 liters '],
+  [/ساعتين/g, ' 2 hours '],
+  [/كوبين/g, ' 2 glasses '],
+  [/دقيقتين/g, ' 2 minutes '],
   [/صرف|أنفق|انفق|دفع|اشتري|اشتر/g, ' spent '],
   [/ربح|كسب|استلم|راتب/g, ' earned '],
   [/دولار/g, ' dollars '],
@@ -43,6 +54,32 @@ const AR_LEXICON = [
   [/قهوة|قهوه/g, ' coffee '],
   [/طعام|وجبة|وجبه|الأكل|أكل|اكل/g, ' food '],
   [/صحية|صحّي|صحي/g, ' healthy '],
+  // Expense-category stems → the English tokens financeCategory() matches.
+  // Without these every non-food Arabic expense lands in "Other".
+  [/باص|حافلة/g, ' bus '],
+  [/تاكسي|تكسي/g, ' taxi '],
+  [/أوبر|اوبر/g, ' uber '],
+  [/بنزين|وقود/g, ' fuel '],
+  [/مواصلات/g, ' transport '],
+  [/قطار/g, ' train '],
+  [/دواء|أدوية|ادوية|علاج/g, ' medicine '],
+  [/صيدلية/g, ' pharmacy '],
+  [/طبيب|دكتور/g, ' doctor '],
+  [/مستشفى/g, ' hospital '],
+  [/نادي|جيم/g, ' gym '],
+  [/فاتورة|فواتير/g, ' bill '],
+  [/كهرباء/g, ' electric '],
+  [/إنترنت|انترنت|النت/g, ' internet '],
+  [/إيجار|ايجار/g, ' rent '],
+  [/ملابس/g, ' clothes '],
+  [/حذاء|أحذية|احذية/g, ' shoes '],
+  [/سوبرماركت|سوبر ماركت|بقالة|خضار|خضروات|فواكه/g, ' groceries '],
+  [/جامعة/g, ' tuition '],
+  [/مدرسة/g, ' school '],
+  [/كتاب/g, ' book '],
+  [/دورة/g, ' course '],
+  [/أدخر|ادخر|ادخار|توفير|وفرت/g, ' save '], // bare وفر would collide with متوفر
+  [/عمل حر|مستقل/g, ' freelance '],
   [/على/g, ' on '], // connector so "<amount> on <purpose>" parses the category
 ];
 const normalizeArabic = (text) => {
@@ -206,7 +243,7 @@ const financeCategory = (text, type) => {
   if (/lunch|breakfast|dinner|food|restaurant|coffee|meal/.test(text)) return 'Food & Dining';
   if (/bus|taxi|uber|fuel|gas|transport|train/.test(text)) return 'Transportation';
   if (/movie|game|concert|entertainment/.test(text)) return 'Entertainment';
-  if (/electric|water bill|internet|rent|utility|utilities|phone bill/.test(text)) return 'Bills & Utilities';
+  if (/electric|water bill|internet|rent|utility|utilities|phone bill|\bbills?\b/.test(text)) return 'Bills & Utilities';
   if (/doctor|medicine|medical|pharmacy|hospital|gym/.test(text)) return 'Healthcare';
   if (/course|school|book|tuition|education/.test(text)) return 'Education';
   if (/grocery|groceries|supermarket/.test(text)) return 'Groceries';

--- a/tests/arabicNlp.test.js
+++ b/tests/arabicNlp.test.js
@@ -92,6 +92,36 @@ describe('Arabic deterministic logging', () => {
     expect(r.response).not.toMatch(/[؀-ۿ]/);
   });
 
+  test('maps Arabic expense stems to real categories, not Other', () => {
+    const cat = (m) => _extractFinanceEntities(m, {})[0]?.category;
+    expect(cat('دفعت ١٥ شيكل للباص')).toBe('Transportation');
+    expect(cat('اشتريت دواء من الصيدلية بـ ٣٠ شيكل')).toBe('Healthcare');
+    expect(cat('دفعت فاتورة الكهرباء ١٠٠ شيكل')).toBe('Bills & Utilities');
+    expect(cat('اشتريت ملابس بـ ٢٠٠ شيكل')).toBe('Shopping');
+    expect(cat('اشتريت خضار من السوبرماركت بـ ٥٠ شيكل')).toBe('Groceries');
+    expect(cat('دفعت رسوم الجامعة ٥٠٠ دولار')).toBe('Education');
+    expect(cat('دفعت اشتراك النادي الرياضي ٥٠ دولار')).toBe('Healthcare');
+    expect(cat('ربحت ٢٠٠ دولار من عمل حر')).toBe('Income - Freelance');
+    expect(cat('وفرت ١٠٠ شيكل هذا الشهر')).toBe('Savings');
+  });
+
+  test('Arabic spending question routes to summary, not expense logging', async () => {
+    const r = await parseMessageWithBert('كم أنفقت هذا الأسبوع؟', null, {});
+    expect(r.intent).toBe('get_insight');
+    const r2 = await parseMessageWithBert('أعطني ملخص الأسبوع', null, {});
+    expect(r2.intent).toBe('get_insight');
+  });
+
+  test('Arabic saving intention routes to set_goal', async () => {
+    const r = await parseMessageWithBert('أريد أن أدخر ٥٠٠ شيكل شهريا', null, {});
+    expect(r.intent).toBe('set_goal');
+  });
+
+  test('Arabic dual forms carry their implicit quantity', () => {
+    expect(_extractHealth('شربت لترين من الماء')[0]).toMatchObject({ type: 'water', value: 2 });
+    expect(_extractHealth('نمت ساعتين')[0]).toMatchObject({ type: 'sleep', value: 2 });
+  });
+
   test('does not disturb English extraction', () => {
     const fin = _extractFinanceEntities('spent $12 on lunch', {});
     expect(fin[0]).toMatchObject({ amount: 12, category: 'Food & Dining' });


### PR DESCRIPTION
## Sprint 10 — Arabic understanding parity

Fact-finding battery (23 realistic Arabic utterances through the deterministic extractor) showed the Arabic pipeline logged amounts fine but:
- every non-food expense → **Other** (باص، دواء، فاتورة، ملابس، سوبرماركت، جامعة، نادي stems unmapped)
- «كم أنفقت هذا الأسبوع؟» → treated as an **expense to log**, asked for an amount
- «أريد أن أدخر ٥٠٠» → logged as expense instead of set_goal
- «ربحت من عمل حر» → Income - Salary instead of Freelance
- dual forms «لترين / ساعتين» extracted nothing

Fixes are all in the existing AR_LEXICON normalization layer (ordered: query/goal phrases before verb stems, duals before singular stems) plus one token in financeCategory. Post-fix battery: 15/15.

## Verification
- root jest: 376 passed (+4 new arabicNlp tests locking categories, intents, duals)
- English extraction regression covered by existing suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)