### PR TITLE
Security: transitive uuid patch via override, 1d access tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ FIREBASE_TOKEN_URI=https://oauth2.googleapis.com/token
 
 # --- JWT ---
 JWT_SECRET=your_jwt_secret_key_min_32_chars
-JWT_EXPIRES_IN=7d
+JWT_EXPIRES_IN=1d
 JWT_REFRESH_SECRET=your_refresh_secret_key
 JWT_REFRESH_EXPIRES_IN=30d
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6791,20 +6791,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/gaxios/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/gcp-metadata": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
@@ -11550,20 +11536,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/teeny-request/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -11953,13 +11925,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lifesync",
   "version": "1.0.0",
-  "description": "LifeSync — Smart Life Management System. AI-powered health and finance tracking via NLP.",
+  "description": "LifeSync \u2014 Smart Life Management System. AI-powered health and finance tracking via NLP.",
   "main": "server/app.js",
   "scripts": {
     "start": "node scripts/launch.mjs",
@@ -45,7 +45,7 @@
     "express",
     "sequelize"
   ],
-  "author": "LifeSync Team — Birzeit University",
+  "author": "LifeSync Team \u2014 Birzeit University",
   "license": "MIT",
   "nodemonConfig": {
     "watch": [
@@ -89,5 +89,8 @@
     "supertest": "^7.2.2",
     "typescript": "^6.0.3",
     "wrangler": "^4.78.0"
+  },
+  "overrides": {
+    "uuid": "^11.1.1"
   }
 }

--- a/server/utils/tokenUtils.js
+++ b/server/utils/tokenUtils.js
@@ -19,7 +19,9 @@ const generateAccessToken = (user) => {
       role: user.role,
     },
     process.env.JWT_SECRET,
-    { expiresIn: process.env.JWT_EXPIRES_IN || '7d' }
+    // Short-lived by default — the client silently refreshes on 401, so a
+    // leaked access token is only useful for a day, not a week.
+    { expiresIn: process.env.JWT_EXPIRES_IN || '1d' }
   );
 };
 


### PR DESCRIPTION
## Sprint 11 — Security hardening

**Changed:**
- `overrides: { uuid: ^11.1.1 }` — clears all 7 moderate audit findings (GHSA-w5hq-g745-h8pq via firebase-admin/sequelize chains). npm's own "fix" wanted breaking downgrades (firebase-admin 14→10, sequelize 6→3); the override patches the actual vulnerable package instead. `npm audit --omit=dev`: **0 vulnerabilities**. Only `uuid.v4()` is used by those chains (the bug needs a caller-supplied buffer in v3/v5/v6), so real exposure was nil — this is hygiene.
- JWT access-token default 7d → **1d**. Client silently refreshes on 401 using the separately-secreted refresh token — no UX change, 7x smaller stolen-token window.

**Audited clean, no change needed:** helmet, CORS allowlist, trust proxy, bcrypt cost 12, OTP attempt cap + expiry, no hardcoded/fallback secrets, refresh/access secret separation, git history secret scan (the once-tracked `.env.backup.original` blob holds only placeholder values — verified).

**User action still pending (cannot be done from code):** rotate the Cloudflare API token and Railway token that were pasted into the chat session.

## Verification
- root jest: 376 passed
- `npm audit --omit=dev`: 0 vulnerabilities, `npm ls uuid` → 11.1.1 across all chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)